### PR TITLE
Deactivate e2e tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           poetry run pytest tests/unit-tests
 
-      - name: Run E2E tests
-        run: |
-          export ASTRA_DB_TOKEN="${{ secrets.E2E_TESTS_ASTRA_DB_TOKEN }}"
-          export OPEN_AI_KEY="${{ secrets.E2E_TESTS_OPEN_AI_KEY }}"
-          ./dev/run-e2e-tests.sh
+#      - name: Run E2E tests
+#        run: |
+#          export ASTRA_DB_TOKEN="${{ secrets.E2E_TESTS_ASTRA_DB_TOKEN }}"
+#          export OPEN_AI_KEY="${{ secrets.E2E_TESTS_OPEN_AI_KEY }}"
+#          ./dev/run-e2e-tests.sh


### PR DESCRIPTION
CI e2e tests are failing because the Astra account we use is limited to 5 databases.
We should have code to clean the tables.