### PR TITLE
E2E tests: do not drop tables, only truncate

### DIFF
--- a/examples/notebooks/astradb.ipynb
+++ b/examples/notebooks/astradb.ipynb
@@ -811,34 +811,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "096397d8-6622-4685-9f9d-7e238beca467",
-   "metadata": {},
-   "source": [
-    "### Cleanup"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cc1e74f9-5500-41aa-836f-235b1ed5f20c",
-   "metadata": {},
-   "source": [
-    "the following essentially retrieves the `Session` object from CassIO and runs a CQL `DROP TABLE` statement with it:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b5b82c33-0e77-4a37-852c-8d50edbdd991",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cassio.config.resolve_session().execute(\n",
-    "    f\"DROP TABLE {cassio.config.resolve_keyspace()}.cassandra_vector_demo;\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "c10ece4d-ae06-42ab-baf4-4d0ac2051743",
    "metadata": {},
    "source": [

--- a/ragstack-e2e-tests/e2e_tests/compatibility_matrix/test_compatibility_matrix.py
+++ b/ragstack-e2e-tests/e2e_tests/compatibility_matrix/test_compatibility_matrix.py
@@ -36,8 +36,8 @@ def init_vector_db(impl, embedding: Embeddings) -> VectorStore:
         collections = raw_client.get_collections().get("status").get("collections")
         logging.info(f"Existing collections: {collections}")
         for collection_info in collections:
-            logging.info(f"Deleting collection: {collection_info}")
-            raw_client.delete_collection(collection_info)
+            logging.info(f"Truncating collection: {collection_info}")
+            raw_client.truncate_collection(collection_info)
 
         vector_db = AstraDB(
             collection_name=collection,
@@ -52,7 +52,7 @@ def init_vector_db(impl, embedding: Embeddings) -> VectorStore:
 
 def close_vector_db(impl: str, vector_store: VectorStore):
     if impl in [VECTOR_ASTRADB_DEV, VECTOR_ASTRADB_PROD]:
-        vector_store.astra_db.delete_collection(vector_store.collection_name)
+        vector_store.astra_db.truncate_collection(vector_store.collection_name)
     else:
         raise Exception("Unknown vector db implementation: " + impl)
 

--- a/ragstack-e2e-tests/e2e_tests/test_astra.py
+++ b/ragstack-e2e-tests/e2e_tests/test_astra.py
@@ -230,8 +230,8 @@ def init_vector_db(embedding: Embeddings) -> VectorStore:
     collections = raw_client.get_collections().get("status").get("collections")
     logging.info(f"Existing collections: {collections}")
     for collection_info in collections:
-        logging.info(f"Deleting collection: {collection_info}")
-        raw_client.delete_collection(collection_info)
+        logging.info(f"Truncating collection: {collection_info}")
+        raw_client.truncate_collection(collection_info)
 
     vector_db = AstraDB(
         collection_name=collection,
@@ -263,7 +263,7 @@ def environment():
 
 
 def close_vector_db(vector_store: VectorStore):
-    vector_store.astra_db.delete_collection(vector_store.collection_name)
+    vector_store.astra_db.truncate_collection(vector_store.collection_name)
 
 
 def init_embeddings() -> Embeddings:


### PR DESCRIPTION
Dropping a table/collection is problematic.
As we are always using the same name we can ensure that it is empty
