### PR TITLE
Use tox to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,24 +32,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry
-          poetry install --no-root
+          python -m pip install tox
 
       - name: Run ragstack-ai unit tests
         run: |
-          poetry run pytest tests/unit-tests
-
-      - name: Build the distribution package
-        run: |
-          poetry build
-
-      - name: Test the distribution package
-        run: |
-          python -m venv /tmp/venv
-          source /tmp/venv/bin/activate
-          pip install pytest dist/ragstack_ai-*.whl
-          pytest tests/unit-tests
-          deactivate
+          tox
 
       - name: Run notebook tests
         env:
@@ -58,7 +45,7 @@ jobs:
           ASTRA_DB_ID: "${{ secrets.E2E_TESTS_ASTRA_DB_ID }}"
           OPENAI_API_KEY: "${{ secrets.E2E_TESTS_OPEN_AI_KEY }}"
         run: |
-          poetry run pytest --nbmake examples/notebooks/*.ipynb
+          tox -e notebooks
 
       - name: Run E2E tests
         id: e2e-tests
@@ -76,7 +63,7 @@ jobs:
           BEDROCK_AWS_REGION: "${{ secrets.E2E_TESTS_BEDROCK_AWS_REGION }}"
           HUGGINGFACE_HUB_KEY: "${{ secrets.E2E_TESTS_HUGGINGFACE_HUB_KEY }}"
         run: |
-          poetry run tox -c ragstack-e2e-tests
+          tox -c ragstack-e2e-tests
 
       - name: Dump report on Github Summary
         if: always()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+isolated_build = true
+envlist = py311
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest tests
+
+[testenv:notebooks]
+pass_env =
+    ASTRA_DB_APPLICATION_TOKEN
+    ASTRA_DB_API_ENDPOINT
+    ASTRA_DB_ID
+    OPENAI_API_KEY
+deps =
+    pytest
+    nbmake
+commands =
+    pytest --nbmake examples/notebooks


### PR DESCRIPTION
This simplifies the test setup as tox will build the package, install it, and use it to run the tests.
We use the strategy where poetry is only used to build the package: https://python-poetry.org/docs/faq/#is-tox-supported
It means that we don't use the poetry lock. I think this is okay since ragstack is a library so locking the deps doesn't really make sense. On the contrary it's probably better to always pull the latest deps at each CI run so we can see if something breaks.