### PR TITLE
[test] Validate LangChain release 0.0.349rc2 with LC core 0.0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ astrapy = "~0.6.2"
 cassio = "~0.1.3"
 unstructured = "^0.10"
 langchain = { version = "0.0.349rc2", extras = ["openai"] }
-langchain-core = "0.0.12"
+langchain-core = "0.0.13-rc.2"
 llama-index = "0.9.11"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
This is a test PR to run CI against the upcoming releases, as asked by LC team