### PR TITLE
Docs-add-flare-notebook

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -12,5 +12,6 @@
 
 .Examples
 * xref:examples:index.adoc[]
+* xref:examples:flare.adoc[]
 * xref:examples:qa-with-cassio.adoc[]
 * xref:examples:rag-with-cassio.adoc[]

--- a/docs/modules/examples/pages/flare.adoc
+++ b/docs/modules/examples/pages/flare.adoc
@@ -1,0 +1,119 @@
+= Foward-Looking Augmented REtrieval (FLARE)
+
+image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai-examples/blob/main/FLARE.ipynb"]
+
+FLARE is an advanced retrieval technique that combines retrieval and generation in LLMs.
+It enhances the accuracy of responses by iteratively predicting the upcoming sentence to anticipate future content when the model encounters a token it is uncertain about.
+See the original repository link:https://github.com/jzbjyb/FLARE/tree/main[here]{external-link-icon} for more detail.
+
+The basic workflow is:
+
+. Send a query.
+. The model generates tokens while iteratively predicting the upcoming sentence.
+. If the model sees a token with a low probability level, it uses the predicted sentence as a query to retrieve new, relevant documents.
+. The upcoming sentence is regenerated using the retrieved documents.
+. Repeat steps 2-4 until the response is complete.
+
+In this tutorial, you will use an Astra DB vector store, an OpenAI embedding model, an OpenAI LLM, and LangChain to orchestrate FLARE in a RAG pipeline.
+
+include::examples:partial$prerequisites.adoc[]
+
+== Setup
+
+`ragstack-ai` includes all the packages you need to build a FLARE pipeline.
+
+. Install the following libraries.
++
+[source,shell]
+----
+pip install ragstack-ai
+----
++
+. Import dependencies.
++
+[source,python]
+----
+import os
+import getpass
+from langchain.vectorstores.astradb import AstraDB
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.document_loaders import TextLoader
+from langchain.globals import set_verbose
+from langchain.chat_models import ChatOpenAI
+from langchain.llms.openai import OpenAI
+from langchain.chains import FlareChain
+from langchain.chains.flare.base import QuestionGeneratorChain
+----
+
+== Embedding Model and Vector Store
+
+. Configure your embedding model and vector store:
++
+[source,python]
+----
+embedding = OpenAIEmbeddings()
+vstore = AstraDB(
+        collection_name=collection,
+        embedding=embedding,
+        token=astra_token,
+        api_endpoint=astra_endpoint
+    )
+print("Astra vector store configured")
+----
++
+. Retrieve the text of a short story that will be indexed in the vector store:
++
+[source,python]
+----
+curl https://raw.githubusercontent.com/CassioML/cassio-website/main/docs/frameworks/langchain/texts/amontillado.txt --output amontillado.txt
+input = "amontillado.txt"
+----
++
+. Create embeddings by inserting your documents into the vector store.
+The final print statement verifies that the documents were embedded.
++
+[source,python]
+----
+loader = TextLoader(input)
+documents = loader.load_and_split()
+
+inserted_ids = vstore.add_documents(documents)
+print(f"\nInserted {len(inserted_ids)} documents.")
+
+print(vstore.astra_db.collection(collection).find())
+----
+
+== FLARE Chain
+
+Using LangChain's FLARE chain with verbose mode on, we can see exactly what is happening under the hood.
+
+. Set verbose mode and configure FLARE chain:
++
+[source,python]
+----
+from langchain.globals import set_verbose # already imported, just for clarity
+set_verbose(True)
+
+retriever = vstore.as_retriever()
+
+flare = FlareChain.from_llm(
+    llm=ChatOpenAI(temperature=0), 
+    retriever=retriever,
+    max_generation_len=256, 
+    min_prob=0.3,
+)
+----
++
+. Run the FLARE chain with a query:
++
+[source,python]
+----
+query = "Who is Luchesi in relation to Antonio?"
+flare.run(query)
+----
+
+You now have a fully functioning RAG pipeline using the FLARE technique!
+FLARE is one of many ways to improve RAG.
+
+See our other xref:examples:index.adoc[examples] for advanced RAG techniques, as well as evaluation examples that compare results using multiple RAG techniques.
+

--- a/docs/modules/examples/pages/index.adoc
+++ b/docs/modules/examples/pages/index.adoc
@@ -8,6 +8,10 @@ We're actively updating this section, so check back often!
 |===
 | Description | Colab | Documentation
 
+| Orchestrate the advanced FLARE retrieval technique in a RAG pipeline.
+a| image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai-examples/blob/main/FLARE.ipynb"]
+| xref:flare.adoc[]
+
 | Implement a generative Q&A over your own documentation with Astra Vector Search, OpenAI, and CassIO.
 a| image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai-examples/blob/main/QA_with_cassio.ipynb"]
 | xref:qa-with-cassio.adoc[]

--- a/docs/modules/examples/partials/prerequisites.adoc
+++ b/docs/modules/examples/partials/prerequisites.adoc
@@ -1,0 +1,30 @@
+== Prerequisites
+
+You will need a vector-enabled Astra database and an OpenAI Account.
+
+See the xref:ROOT:prerequisites.adoc[] page for more details.
+
+. Create an Astra vector database.
+. Create an OpenAI account
+. Within your database, create an Astra DB keyspace
+. Within your database, create an Astra DB Access Token with Database Administrator permissions.
+. Get your Astra DB Endpoint: `https://<ASTRA_DB_ID>-<ASTRA_DB_REGION>.apps.astra.datastax.com`
+. Initialize the environment variables in a `.env` file.
++
+[source,python]
+----
+ASTRA_DB_APPLICATION_TOKEN=AstraCS:...
+ASTRA_DB_API_ENDPOINT=https://2d6b7600-886e-4852-8f9a-1b59508dg040-us-east-2.apps.astra.datastax.com
+ASTRA_DB_COLLECTION=test
+OPENAI_API_KEY=sk-f13...
+----
++
+. Enter your settings for Astra DB and OpenAI:
++
+[source,python]
+----
+astra_token = os.getenv("ASTRA_DB_APPLICATION_TOKEN")
+astra_endpoint = os.getenv("ASTRA_DB_API_ENDPOINT")
+collection = os.getenv("ASTRA_DB_COLLECTION")
+openai_key = os.getenv("OPENAI_API_KEY")
+----


### PR DESCRIPTION
* Add FLARE notebook to index, docs page, nav, and colab link (not published yet). 
* Added a [partial](https://github.com/datastax/ragstack-ai/compare/docs-add-flare-notebook?expand=1#diff-83f94f51e2ef5cbee0ea79897ab5e7a9e2b00147d3eaf1ab99c26a94b41062db) for ragstack and astra setup -  if we can standardize on these setup variables, it will make setup easier to read and require less writing.

WDYT @jordanrfrazier ?

astra_token = os.getenv("ASTRA_DB_APPLICATION_TOKEN")
astra_endpoint = os.getenv("ASTRA_DB_API_ENDPOINT")
collection = os.getenv("ASTRA_DB_COLLECTION")
openai_key = os.getenv("OPENAI_API_KEY")

