### PR TITLE
CI: Add LC api key to CI secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           ASTRA_DB_API_ENDPOINT: "${{ steps.astra-db.outputs.db_endpoint }}"
           ASTRA_DB_ID: "${{ steps.astra-db.outputs.db_id }}"
           OPENAI_API_KEY: "${{ secrets.E2E_TESTS_OPEN_AI_KEY }}"
+          LANGCHAIN_API_KEY: "${{ secrets.E2E_TESTS_LANGCHAIN_API_KEY }}"
         run: |
           tox -e notebooks
 


### PR DESCRIPTION
https://github.com/datastax/ragstack-ai/pull/134/files requires the langchain API key, but CI needs to know about it first before those notebook tests pass 