### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ pip install ragstack-ai
 
 [Examples](https://docs.datastax.com/en/ragstack/docs/examples/index.html)
 
-[What is RAG?](https://docs.datastax.com/en/ragstack/docs/intro-to-rag/index.html)
-
 ## Contributing and building locally
 
 1. Clone this repo:

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ pip install ragstack-ai
 ## Documentation
 
 [DataStax RAGStack Documentation](https://docs.datastax.com/en/ragstack/docs/index.html)
-* [Quickstart](https://docs.datastax.com/en/ragstack/docs/quickstart.html)
-* [Examples](https://docs.datastax.com/en/ragstack/docs/examples/index.html)
-* [What is RAG?](https://docs.datastax.com/en/ragstack/docs/intro-to-rag/index.html)
+
+[Quickstart](https://docs.datastax.com/en/ragstack/docs/quickstart.html)
+
+[Examples](https://docs.datastax.com/en/ragstack/docs/examples/index.html)
+
+[What is RAG?](https://docs.datastax.com/en/ragstack/docs/intro-to-rag/index.html)
 
 ## Contributing and building locally
 


### PR DESCRIPTION
The bulleted docs.datastax.com links 403 if you access them from /blob/main. 
There are some other GitHub issues around this bug elsewhere. For now I'm just going to remove the bullets. 