### PR TITLE
docs: add rag/qa with cassio notebooks

### DIFF
--- a/docs/modules/examples/pages/index.adoc
+++ b/docs/modules/examples/pages/index.adoc
@@ -9,11 +9,11 @@ We're actively updating this section, so check back often!
 | Description | Colab | Documentation
 
 | Implement a generative Q&A over your own documentation with Astra Vector Search, OpenAI, and CassIO.
-a| image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai-examples/blob/main/QA_with_cassio.ipynb"]
+a| image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai/blob/main/examples/notebooks/QA_with_cassio.ipynb"]
 | xref:qa-with-cassio.adoc[]
 
 | Store external or proprietary data in Astra DB and query it to provide more up-to-date LLM responses.
-a| image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai-examples/blob/main/RAG_with_cassio.ipynb"]
+a| image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai/blob/main/examples/notebooks/RAG_with_cassio.ipynb"]
 | xref:rag-with-cassio.adoc[]
 
 | Evaluate a RAG pipeline using LangChain's QA Evaluator.

--- a/docs/modules/examples/pages/qa-with-cassio.adoc
+++ b/docs/modules/examples/pages/qa-with-cassio.adoc
@@ -1,6 +1,6 @@
 = Knowledge Base Search on Proprietary Data powered by Astra DB
 
-image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai-examples/blob/main/QA_with_cassio.ipynb"]
+image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai/blob/main/examples/notebooks/QA_with_cassio.ipynb"]
 
 This notebook guides you through setting up RAGStack using https://docs.datastax.com/en/astra-serverless/docs/vector-search/overview.html[Astra Vector Search], https://platform.openai.com[OpenAI], and https://cassio.org/[CassIO] to implement a generative Q&A over your own documentation.
 

--- a/docs/modules/examples/pages/rag-with-cassio.adoc
+++ b/docs/modules/examples/pages/rag-with-cassio.adoc
@@ -2,7 +2,7 @@
 :toc: macro
 :toc-title:
 
-image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai-examples/blob/main/RAG_with_cassio.ipynb"]
+image::https://colab.research.google.com/assets/colab-badge.svg[align="left",link="https://colab.research.google.com/github/datastax/ragstack-ai/blob/main/examples/notebooks/RAG_with_cassio.ipynb"]
 
 Large Language Models (LLMs) have a data freshness problem. The most powerful LLMs in the world, like GPT-4, have no idea about recent world events.
 

--- a/examples/notebooks/QA_with_cassio.ipynb
+++ b/examples/notebooks/QA_with_cassio.ipynb
@@ -1,0 +1,503 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/datastax/ragstack-ai/blob/main/examples/notebooks/QA_with_cassio.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "cf05e3f2",
+      "metadata": {
+        "id": "cf05e3f2"
+      },
+      "source": [
+        "# Knowledge Base Search on Proprietary Data powered by Astra DB\n",
+        "This notebook guides you through setting up [RAGStack](https://www.datastax.com/products/ragstack) using [Astra Vector Search](https://docs.datastax.com/en/astra-serverless/docs/vector-search/overview.html), [OpenAI](https://openai.com/about), and [CassIO](https://cassio.org/) to implement a generative Q&A over your own documentation.\n",
+        "\n",
+        "## Astra Vector Search\n",
+        "Astra vector search enables developers to search a database by context or meaning rather than keywords or literal values. This is done by using “embeddings”. Embeddings are a type of representation used in machine learning where high-dimensional or complex data is mapped onto vectors in a lower-dimensional space. These vectors capture the semantic properties of the input data, meaning that similar data points have similar embeddings.\n",
+        "Reference: [Astra Vector Search](https://docs.datastax.com/en/astra-serverless/docs/vector-search/overview.html)\n",
+        "\n",
+        "## CassIO\n",
+        "CassIO is the ultimate solution for seamlessly integrating Apache Cassandra® with generative artificial intelligence and other machine learning workloads. This powerful Python library simplifies the complicated process of accessing the advanced features of the Cassandra database, including vector search capabilities. With CassIO, developers can fully concentrate on designing and perfecting their AI systems without any concerns regarding the complexities of integration with Cassandra.\n",
+        "Reference: [CassIO](https://cassio.org/)\n",
+        "\n",
+        "## OpenAI\n",
+        "OpenAI provides various tools and resources to implement your own Document QA Search system. This includes pre-trained language models like GPT-4, which can understand and generate human-like text. Additionally, OpenAI offers guidelines and APIs to leverage their models for document search and question-answering tasks, enabling developers to build powerful and intelligent Document QA Search applications.\n",
+        "Reference: [OpenAI](https://openai.com/about)\n",
+        "\n",
+        "## Demo Summary\n",
+        "ChatGPT excels at answering questions, but only on topics it knows from its training data. It offers you a nice dialog interface to ask questions and get answers.\n",
+        "\n",
+        "But what do you do when you have your own documents? How can you leverage the GenAI and LLM models to get insights into those? We can use Retrieval Augmented Generation (RAG) -- think of a Q/A Bot that can answer specific questions over your documentation.\n",
+        "\n",
+        "We can do this in two easy steps:\n",
+        "1. Analyzing and storing existing documentation.\n",
+        "2. Providing search capabilities for the model to retrieve your documentation.\n",
+        "\n",
+        "This is solved by using LLM models. Ideally you embed the data as vectors and store them in a vector database and then use the LLM models on top of that database.\n",
+        "\n",
+        "This notebook demonstrates a basic two-step RAG technique for enabling GPT to answer questions using a library of reference on your own documentation using Astra DB Vector Search."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "651400d1",
+      "metadata": {
+        "id": "651400d1"
+      },
+      "source": [
+        "# Getting Started with this notebook\n",
+        "\n",
+        "* Follow [these steps](https://docs.datastax.com/en/astra-serverless/docs/vector-search/overview.html) to create a new vector search enabled database in Astra.\n",
+        "* Generate a new [\"Database Administrator\" token](https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-tokens.html).\n",
+        "* Download the secure connect bundle for the database you just created (you can do this from the \"Connect\" tab of your database).\n",
+        "* You will also need the necessary secret for the LLM provider of your choice:\n",
+        "  * If Open AI, then you will need an [Open AI API Key](https://help.openai.com/en/articles/4936850-where-do-i-find-my-secret-api-key). This will require an Open AI account with billing enabled.\n",
+        "  * If Vertex AI, you will need a config file.\n",
+        "  * For more details, see [Pre-requisites](https://cassio.org/start_here/#llm-access) on cassio.org.\n",
+        "\n",
+        "\n",
+        "When you run this notebook, it will ask you to provide each of these items at various steps."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "311cc2e9",
+      "metadata": {
+        "id": "311cc2e9"
+      },
+      "source": [
+        "# Setup\n",
+        "\n",
+        "Install the following libraries."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a6d88d66",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "a6d88d66",
+        "outputId": "dc543d17-3fb2-4362-cc4e-0050bd7787ba"
+      },
+      "outputs": [],
+      "source": [
+        "# install required dependencies\n",
+        "! pip install \\\n",
+        "    \"ragstack-ai\" \\\n",
+        "    \"pypdf\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ae20e0b5",
+      "metadata": {
+        "id": "ae20e0b5"
+      },
+      "source": [
+        "# Imports"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "16f9f33a",
+      "metadata": {
+        "id": "16f9f33a"
+      },
+      "outputs": [],
+      "source": [
+        "from cassandra.cluster import Cluster\n",
+        "from cassandra.auth import PlainTextAuthProvider"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5usSnhULsaLV",
+      "metadata": {
+        "id": "5usSnhULsaLV"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "from getpass import getpass\n",
+        "\n",
+        "try:\n",
+        "    from google.colab import files\n",
+        "    IS_COLAB = True\n",
+        "except ModuleNotFoundError:\n",
+        "    IS_COLAB = False"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4df2888e",
+      "metadata": {
+        "id": "4df2888e"
+      },
+      "source": [
+        "# Astra DB configuration, Secure Connection Bundle, and Token\n",
+        "\n",
+        "You will need a secure connect bundle and a user with access permission. For demo purposes the \"administrator\" role will work fine.\n",
+        "More information about how to get the bundle can be found [here](https://docs.datastax.com/en/astra-serverless/docs/connect/secure-connect-bundle.html)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "QvY0HTqm3chY",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 142
+        },
+        "id": "QvY0HTqm3chY",
+        "outputId": "d563332e-8353-41de-f751-506101450243"
+      },
+      "outputs": [],
+      "source": [
+        "# Your database's Secure Connect Bundle zip file is needed:\n",
+        "if IS_COLAB:\n",
+        "    print('Please upload your Secure Connect Bundle zipfile: ')\n",
+        "    uploaded = files.upload()\n",
+        "    if uploaded:\n",
+        "        astraBundleFileTitle = list(uploaded.keys())[0]\n",
+        "        ASTRA_DB_SECURE_BUNDLE_PATH = os.path.join(os.getcwd(), astraBundleFileTitle)\n",
+        "    else:\n",
+        "        raise ValueError(\n",
+        "            'Cannot proceed without Secure Connect Bundle. Please re-run the cell.'\n",
+        "        )\n",
+        "else:\n",
+        "    # you are running a local-jupyter notebook:\n",
+        "    ASTRA_DB_SECURE_BUNDLE_PATH = input(\"Please provide the full path to your Secure Connect Bundle zipfile: \")\n",
+        "\n",
+        "ASTRA_DB_APPLICATION_TOKEN = getpass(\"Please provide your Database Token ('AstraCS:...' string): \")\n",
+        "ASTRA_DB_KEYSPACE = input(\"Please provide the Keyspace name for your Database: \")\n",
+        "# define the table name to be used to store our embeddings, CassIO will create the objects in Astra DB for you.\n",
+        "# To avoid incompatibilities with existing tables, use a new table name. \n",
+        "ASTRA_DB_TABLE_NAME = input(\"Please provide the name of the table to be created: \")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "tyZ1IC4d3U15",
+      "metadata": {
+        "id": "tyZ1IC4d3U15"
+      },
+      "source": [
+        "# Provide Sample Data\n",
+        "A sample document is provided from CassIO. You may provide your own files instead in the following cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1VsVGojG663U",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "1VsVGojG663U",
+        "outputId": "c81811af-1968-448c-ff70-7e54a5adb746"
+      },
+      "outputs": [],
+      "source": [
+        "# retrieve the text of a short story that will be indexed in the vector store\n",
+        "! curl https://raw.githubusercontent.com/CassioML/cassio-website/main/docs/frameworks/langchain/texts/amontillado.txt --output amontillado.txt\n",
+        "SAMPLEDATA = [\"amontillado.txt\"]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "PjxwchCO3n_8",
+      "metadata": {
+        "id": "PjxwchCO3n_8"
+      },
+      "outputs": [],
+      "source": [
+        "# Alternatively, provide your own file. However, you will want to update your queries to match the content of your file. \n",
+        "\n",
+        "# Upload sample file (Note: this assumes you are on Google Colab. Local Jupyter notebooks can provide the path to their files directly by uncommenting and running just the next line).\n",
+        "# SAMPLEDATA = [\"<path_to_file>\"]\n",
+        "\n",
+        "print('Please upload your own sample file:')\n",
+        "uploaded = files.upload()\n",
+        "if uploaded:\n",
+        "    SAMPLEDATA = uploaded\n",
+        "else:\n",
+        "    raise ValueError(\n",
+        "        'Cannot proceed without Sample Data. Please re-run the cell.'\n",
+        "    )\n",
+        "\n",
+        "print(f'Please make sure to change your queries to match the contents of your file!')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "33e090e7",
+      "metadata": {
+        "id": "33e090e7"
+      },
+      "source": [
+        "# Connect to Astra DB"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e8c527a1",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "e8c527a1",
+        "outputId": "0b40a4b2-6f57-48c3-cee1-52c6096f26b1"
+      },
+      "outputs": [],
+      "source": [
+        "# Don't mind the \"Closing connection\" error after \"downgrading protocol...\" messages,\n",
+        "# it is really just a warning: the connection will work smoothly.\n",
+        "cluster = Cluster(\n",
+        "    cloud={\n",
+        "        \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
+        "    },\n",
+        "    auth_provider=PlainTextAuthProvider(\n",
+        "        \"token\",\n",
+        "        ASTRA_DB_APPLICATION_TOKEN,\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "session = cluster.connect()\n",
+        "keyspace = ASTRA_DB_KEYSPACE"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8251382e",
+      "metadata": {
+        "id": "8251382e"
+      },
+      "source": [
+        "# Read Files, Create Embeddings, Store in Vector DB\n",
+        "\n",
+        "CassIO seamlessly integrates with RAGStack and LangChain, offering Cassandra-specific tools for many tasks. In our example we will use vector stores, indexers, embeddings, and queries.\n",
+        "\n",
+        "We will use OpenAI for our LLM services. (See [cassio.org](https://cassio.org/start_here/#llm-access) for more details)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "J5VPZclr6n67",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "J5VPZclr6n67",
+        "outputId": "4837f954-06a4-430f-dd1f-5ed9c2f891f4"
+      },
+      "outputs": [],
+      "source": [
+        "# We will use OpenAI embeddings, so please provide your OpenAI API Key\n",
+        "OPENAI_API_KEY = getpass(\"Please enter your OpenAI API Key: \")\n",
+        "os.environ['OPENAI_API_KEY'] = OPENAI_API_KEY"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "TE5pZsfs7iPT",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "TE5pZsfs7iPT",
+        "outputId": "c10f1bc5-7448-4b78-f416-034a5428da32"
+      },
+      "outputs": [],
+      "source": [
+        "# Import the needed libraries and declare the LLM model\n",
+        "from langchain.embeddings import OpenAIEmbeddings\n",
+        "from langchain.vectorstores import Cassandra\n",
+        "from langchain.document_loaders import TextLoader\n",
+        "from langchain.document_loaders import PyPDFLoader\n",
+        "\n",
+        "# Loop through each file and load it into our vector store\n",
+        "documents = []\n",
+        "for filename in SAMPLEDATA:\n",
+        "  path = os.path.join(os.getcwd(), filename)\n",
+        "\n",
+        "  # Supported file types are pdf and txt\n",
+        "  if filename.endswith(\".pdf\"):\n",
+        "    loader = PyPDFLoader(path)\n",
+        "    new_docs = loader.load_and_split()\n",
+        "    print(f\"Processed pdf file: {filename}\")\n",
+        "  elif filename.endswith(\".txt\"):\n",
+        "    loader = TextLoader(path)\n",
+        "    new_docs = loader.load_and_split()\n",
+        "    print(f\"Processed txt file: {filename}\")\n",
+        "  else:\n",
+        "    print(f\"Unsupported file type: {filename}\")\n",
+        "\n",
+        "  if len(new_docs) > 0:\n",
+        "    documents.extend(new_docs)\n",
+        "\n",
+        "cassVStore = Cassandra.from_documents(\n",
+        "  documents=documents,\n",
+        "  embedding=OpenAIEmbeddings(),\n",
+        "  session=session,\n",
+        "  keyspace=ASTRA_DB_KEYSPACE,\n",
+        "  table_name=ASTRA_DB_TABLE_NAME,\n",
+        ")\n",
+        "\n",
+        "# empty the list of file names -- we don't want to accidentally load the same files again\n",
+        "SAMPLEDATA = []\n",
+        "\n",
+        "print(f\"\\nProcessing done.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "oTEglBjbaHDj",
+      "metadata": {
+        "id": "oTEglBjbaHDj"
+      },
+      "source": [
+        "# Now Query the Data and execute some \"searches\" against it\n",
+        "First we will start with a similarity search using the Vectorstore's implementation"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "yaFkjaAnCIRw",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "yaFkjaAnCIRw",
+        "outputId": "b5f7b7ce-4649-4ad6-f715-1a4d9ffdf4d0"
+      },
+      "outputs": [],
+      "source": [
+        "# construct your query\n",
+        "prompt = \"Who is Luchesi?\"\n",
+        "\n",
+        "# find matching documentation using similarity search\n",
+        "matched_docs = cassVStore.similarity_search(query=prompt, k=1)\n",
+        "\n",
+        "# print out the relevant context that an LLM will use to produce an answer\n",
+        "for i, d in enumerate(matched_docs):\n",
+        "    print(f\"\\n## Document {i}\\n\")\n",
+        "    print(d.page_content)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9cVulGW6aom5",
+      "metadata": {
+        "id": "9cVulGW6aom5"
+      },
+      "source": [
+        "# Finally do a Q/A Search\n",
+        "To be able implement Q/A over documents we need to perform the following steps:\n",
+        "\n",
+        "1. Create an Index on top of our vector store\n",
+        "2. Create a Retriever from that Index\n",
+        "3. Ask questions (prompts)!\n",
+        "\n",
+        "A retriever is an interface that returns documents given an unstructured query. It is more general than a vector store. A retriever does not need to be able to store documents, only to return (or retrieve) them. Vector stores can be used as the backbone of a retriever."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cptnBJhCWTz0",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 211
+        },
+        "id": "cptnBJhCWTz0",
+        "outputId": "106cefaa-4dd4-4b5c-80ec-574a6697bd7b"
+      },
+      "outputs": [],
+      "source": [
+        "# Q/A LLM Search\n",
+        "from langchain.chat_models import ChatOpenAI\n",
+        "from langchain.indexes.vectorstore import VectorStoreIndexWrapper\n",
+        "\n",
+        "index = VectorStoreIndexWrapper(vectorstore=cassVStore)\n",
+        "\n",
+        "# Query the index for relevant vectors to our prompt\n",
+        "prompt = \"Who is Luchesi?\"\n",
+        "index.query(question=prompt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "kYz1Jdl1Qhuj",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 71
+        },
+        "id": "kYz1Jdl1Qhuj",
+        "outputId": "d4bb9005-468d-4f9f-e1cb-6f2de4caacbb"
+      },
+      "outputs": [],
+      "source": [
+        "# Alternatively, you can use a retrieval chain with a custom prompt\n",
+        "from langchain.chains import RetrievalQA\n",
+        "from langchain.llms import OpenAI\n",
+        "from langchain.prompts import ChatPromptTemplate\n",
+        "\n",
+        "prompt= \"\"\"\n",
+        "You are Marv, a sarcastic but factual chatbot.\n",
+        "Context: {context}\n",
+        "Question: {question}\n",
+        "Your answer:\n",
+        "\"\"\"\n",
+        "prompt = ChatPromptTemplate.from_template(prompt)\n",
+        "\n",
+        "qa = RetrievalQA.from_chain_type(llm=OpenAI(), retriever=cassVStore.as_retriever(), chain_type_kwargs={\"prompt\": prompt})\n",
+        "\n",
+        "result = qa.run(\"{question: Who is Luchesi?\")\n",
+        "result\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.4"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/examples/notebooks/RAG_with_cassio.ipynb
+++ b/examples/notebooks/RAG_with_cassio.ipynb
@@ -1,0 +1,623 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/datastax/ragstack-ai/blob/main/examples/notebooks/RAG_with_cassio.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "pvPcHxhErXbg",
+      "metadata": {
+        "id": "pvPcHxhErXbg"
+      },
+      "source": [
+        "# **RAGStack with CassIO**\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "oLHkt-bMq4up",
+      "metadata": {
+        "id": "oLHkt-bMq4up"
+      },
+      "source": [
+        "## **Introduction**\n",
+        "Large Language Models (LLMs) have a data freshness problem. The most powerful LLMs in the world, like GPT-4, have no idea about recent world events.\n",
+        "\n",
+        "The world of LLMs is frozen in time. Their world exists as a static snapshot of the world as it was within their training data.\n",
+        "\n",
+        "A solution to this problem is Retrieval Augmentated Generation (RAG). The idea behind this is that we retrieve relevant information from an external knowledge base and give that information to our LLM. In this notebook we will learn how to do that. In this demo, external or proprietary data will be stored in Astra DB and used to provide more current LLM responses."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "WQUeV_S5q4u0",
+      "metadata": {
+        "id": "WQUeV_S5q4u0"
+      },
+      "source": [
+        "## **Prerequisites Setup**\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "Z1p8iUgjq4u2",
+      "metadata": {
+        "id": "Z1p8iUgjq4u2"
+      },
+      "source": [
+        "* Follow [these steps](https://docs.datastax.com/en/astra-serverless/docs/vector-search/overview.html) to create a new vector search enabled database in Astra.\n",
+        "* Generate a new [\"Database Administrator\" token](https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-tokens.html).\n",
+        "* Download the secure connect bundle for the database you just created (you can do this from the \"Connect\" tab of your database).\n",
+        "* You will also need the necessary secret for the LLM provider of your choice:\n",
+        "  * If Open AI, then you will need an [Open AI API Key](https://help.openai.com/en/articles/4936850-where-do-i-find-my-secret-api-key). This will require an Open AI account with billing enabled.\n",
+        "  * If Vertex AI, you will need a config file.\n",
+        "  * For more details, see [Pre-requisites](https://cassio.org/start_here/#llm-access) on cassio.org.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "2953d95b",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "2953d95b",
+        "outputId": "f1d1a4dc-9984-405d-bf28-74697815ea12"
+      },
+      "outputs": [],
+      "source": [
+        "# install required dependencies\n",
+        "! pip install ragstack-ai datasets google-cloud-aiplatform pandas "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "222f44ff",
+      "metadata": {
+        "id": "222f44ff"
+      },
+      "source": [
+        "You may be asked to \"Restart the Runtime\" at this time, as some dependencies\n",
+        "have been upgraded. **Please do restart the runtime now** for a smoother execution from this point onward."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "qSZ3-OG5Kdh6",
+      "metadata": {
+        "id": "qSZ3-OG5Kdh6"
+      },
+      "source": [
+        "## **Astra DB Setup**\n",
+        "The following steps will ask for the keyspace of the vector search enabled Astra DB that you want to use for this example, as well as the Astra DB Token that you generated as part of the prerequisites. You will also require to upload the [Secure Connect Bundle](https://awesome-astra.github.io/docs/pages/astra/download-scb/#c-procedure).\n",
+        "\n",
+        "Lastly, we are going to create helper functions for a secure connection to Astra DB `getCQLSession` `getCQLKeyspace` and `getTableCount`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "zh4P-XUDq4u9",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "zh4P-XUDq4u9",
+        "outputId": "6108b384-addf-4b7a-e340-858a9ff76dfb"
+      },
+      "outputs": [],
+      "source": [
+        "# Input your database keyspace name:\n",
+        "ASTRA_DB_KEYSPACE = input('Your Astra DB Keyspace name: ')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "lThGqYchq4u-",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "lThGqYchq4u-",
+        "outputId": "e5d8614f-54b3-47c0-df0d-b66ff1185354"
+      },
+      "outputs": [],
+      "source": [
+        "from getpass import getpass\n",
+        "# Input your Astra DB token string, the one starting with \"AstraCS:...\"\n",
+        "ASTRA_DB_TOKEN_BASED_PASSWORD = getpass('Your Astra DB Token: ')\n",
+        "# To avoid incompatibilities with existing tables, use a new table name\n",
+        "ASTRA_DB_TABLE_NAME = input(\"Please provide the name of the table to be created: \")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "xnNziXZ1q4vD",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 90
+        },
+        "id": "xnNziXZ1q4vD",
+        "outputId": "4802a65d-ff16-4f91-e99a-1776d710ec47"
+      },
+      "outputs": [],
+      "source": [
+        "# Upload your Secure Connect Bundle zipfile:\n",
+        "# (Note - this notebook only works in google colab)\n",
+        "import os\n",
+        "from google.colab import files\n",
+        "\n",
+        "print('Please upload your Secure Connect Bundle')\n",
+        "uploaded = files.upload()\n",
+        "if uploaded:\n",
+        "    astraBundleFileTitle = list(uploaded.keys())[0]\n",
+        "    ASTRA_DB_SECURE_BUNDLE_PATH = os.path.join(os.getcwd(), astraBundleFileTitle)\n",
+        "else:\n",
+        "    raise ValueError(\n",
+        "        'Cannot proceed without Secure Connect Bundle. Please re-run the cell.'\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "TUDw-07Iq4vE",
+      "metadata": {
+        "id": "TUDw-07Iq4vE"
+      },
+      "outputs": [],
+      "source": [
+        "# colab-specific override of helper functions\n",
+        "from cassandra.cluster import (\n",
+        "    Cluster,\n",
+        ")\n",
+        "from cassandra.auth import PlainTextAuthProvider\n",
+        "from cassandra.query import SimpleStatement\n",
+        "\n",
+        "# The \"username\" is the literal string 'token' for this connection mode:\n",
+        "ASTRA_DB_TOKEN_BASED_USERNAME = 'token'\n",
+        "\n",
+        "\n",
+        "def getCQLSession(mode='astra_db'):\n",
+        "    if mode == 'astra_db':\n",
+        "        cluster = Cluster(\n",
+        "            cloud={\n",
+        "                \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
+        "            },\n",
+        "            auth_provider=PlainTextAuthProvider(\n",
+        "                ASTRA_DB_TOKEN_BASED_USERNAME,\n",
+        "                ASTRA_DB_TOKEN_BASED_PASSWORD,\n",
+        "            ),\n",
+        "        )\n",
+        "        astraSession = cluster.connect()\n",
+        "        return astraSession\n",
+        "    else:\n",
+        "        raise ValueError('Unsupported CQL Session mode')\n",
+        "\n",
+        "def getCQLKeyspace(mode='astra_db'):\n",
+        "    if mode == 'astra_db':\n",
+        "        return ASTRA_DB_KEYSPACE\n",
+        "    else:\n",
+        "        raise ValueError('Unsupported CQL Session mode')\n",
+        "\n",
+        "def getTableCount():\n",
+        "  # create a query that counts the number of records of the Astra DB table\n",
+        "  query = SimpleStatement(f\"\"\"SELECT COUNT(*) FROM {keyspace}.{table_name};\"\"\")\n",
+        "\n",
+        "  # execute the query\n",
+        "  results = session.execute(query)\n",
+        "  return results.one().count\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "QXCQ6T_Gjk0Oz",
+      "metadata": {
+        "id": "QXCQ6T_Gjk0Oz"
+      },
+      "source": [
+        "## **LLM Provider**\n",
+        "\n",
+        "In the cell below you can choose between **GCP VertexAI** or **OpenAI** for your LLM services.\n",
+        "(See [Pre-requisites](https://cassio.org/start_here/#llm-access) on cassio.org for more details).\n",
+        "\n",
+        "Make sure you set the `llmProvider` variable and supply the corresponding access secrets in the following cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "pGpzZc5zq4vG",
+      "metadata": {
+        "id": "pGpzZc5zq4vG"
+      },
+      "outputs": [],
+      "source": [
+        "# Set your secret(s) for LLM access:\n",
+        "llmProvider = 'OpenAI'  # 'GCP_VertexAI'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "zOFStlEAq4vH",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "zOFStlEAq4vH",
+        "outputId": "3d28b021-0771-4f64-bce9-f9d598996ba5"
+      },
+      "outputs": [],
+      "source": [
+        "if llmProvider == 'OpenAI':\n",
+        "    apiSecret = getpass(f'Your secret for LLM provider \"{llmProvider}\": ')\n",
+        "    os.environ['OPENAI_API_KEY'] = apiSecret\n",
+        "elif llmProvider == 'GCP_VertexAI':\n",
+        "    # we need a json file\n",
+        "    print(f'Please upload your Service Account JSON for the LLM provider \"{llmProvider}\":')\n",
+        "    from google.colab import files\n",
+        "    uploaded = files.upload()\n",
+        "    if uploaded:\n",
+        "        vertexAIJsonFileTitle = list(uploaded.keys())[0]\n",
+        "        os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = os.path.join(os.getcwd(), vertexAIJsonFileTitle)\n",
+        "    else:\n",
+        "        raise ValueError(\n",
+        "            'No file uploaded. Please re-run the cell.'\n",
+        "        )\n",
+        "else:\n",
+        "    raise ValueError('Unknown/unsupported LLM Provider')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "eZS2Xsy0WY-c",
+      "metadata": {
+        "id": "eZS2Xsy0WY-c"
+      },
+      "source": [
+        "# Provide Sample Data\n",
+        "A sample document is provided from CassIO. You may provide your own files instead in the following cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "OzxSvKT2W57Z",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "OzxSvKT2W57Z",
+        "outputId": "3fee419d-7a20-463e-a5f2-ab926a75632d"
+      },
+      "outputs": [],
+      "source": [
+        "# retrieve the text of a short story that will be indexed in the vector store\n",
+        "! curl https://raw.githubusercontent.com/CassioML/cassio-website/main/docs/frameworks/langchain/texts/amontillado.txt --output amontillado.txt\n",
+        "SAMPLEDATA = [\"amontillado.txt\"]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Alternatively, provide your own file. However, you will want to update your queries to match the content of your file. \n",
+        "\n",
+        "# Upload sample file (Note: this assumes you are on Google Colab. Local Jupyter notebooks can provide the path to their files directly by uncommenting and running just the next line).\n",
+        "# SAMPLEDATA = [\"<path_to_file>\"]\n",
+        "\n",
+        "print('Please upload your own sample file:')\n",
+        "uploaded = files.upload()\n",
+        "if uploaded:\n",
+        "    SAMPLEDATA = uploaded\n",
+        "else:\n",
+        "    raise ValueError(\n",
+        "        'Cannot proceed without Sample Data. Please re-run the cell.'\n",
+        "    )\n",
+        "\n",
+        "\n",
+        "print(f'Please make sure to change your queries to match the contents of your file!')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6715bc2b",
+      "metadata": {
+        "id": "6715bc2b"
+      },
+      "source": [
+        "# Vector Similarity Search QA Quickstart"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "761d9b70",
+      "metadata": {
+        "id": "761d9b70"
+      },
+      "source": [
+        "_**NOTE:** this uses Cassandra's \"Vector Similarity Search\" capability.\n",
+        "Make sure you are connecting to a vector-enabled database for this demo._"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4578a87b",
+      "metadata": {
+        "id": "4578a87b"
+      },
+      "source": [
+        "A database connection is needed to access Cassandra. The following assumes\n",
+        "that a _vector-search-capable Astra DB instance_ is available. Adjust as needed."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "11013224",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "11013224",
+        "outputId": "4bf5e8a3-036e-433e-9c2b-4f7e2b5fc157"
+      },
+      "outputs": [],
+      "source": [
+        "# Don't mind the \"Closing connection\" error after \"downgrading protocol...\" messages,\n",
+        "# it is really just a warning: the connection will work smoothly.\n",
+        "cqlMode = 'astra_db'\n",
+        "session = getCQLSession(mode=cqlMode)\n",
+        "keyspace = getCQLKeyspace(mode=cqlMode)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "32e2a156",
+      "metadata": {
+        "id": "32e2a156"
+      },
+      "source": [
+        "Both an LLM and an embedding function are required.\n",
+        "\n",
+        "Below is the logic to instantiate the LLM and embeddings of choice. We choose to leave it in the notebooks for clarity."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "124e3de4",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "124e3de4",
+        "outputId": "1832f236-fe61-4773-e045-89358e647d04"
+      },
+      "outputs": [],
+      "source": [
+        "# creation of the LLM resources\n",
+        "from langchain.chat_models import ChatOpenAI\n",
+        "\n",
+        "if llmProvider == 'GCP_VertexAI':\n",
+        "    from langchain.llms import VertexAI\n",
+        "    from langchain.embeddings import VertexAIEmbeddings\n",
+        "    llm = VertexAI()\n",
+        "    myEmbedding = VertexAIEmbeddings()\n",
+        "    print('LLM+embeddings from VertexAI')\n",
+        "elif llmProvider == 'OpenAI':\n",
+        "    from langchain.llms import OpenAI\n",
+        "    from langchain.embeddings import OpenAIEmbeddings\n",
+        "    llm = ChatOpenAI(temperature=0)\n",
+        "    myEmbedding = OpenAIEmbeddings()\n",
+        "    print('LLM+embeddings from OpenAI')\n",
+        "else:\n",
+        "    raise ValueError('Unknown LLM provider.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "285f29cf",
+      "metadata": {
+        "id": "285f29cf"
+      },
+      "source": [
+        "## Langchain Retrieval Augmentation"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5cf74a31",
+      "metadata": {
+        "id": "5cf74a31"
+      },
+      "source": [
+        "The following is a minimal usage of the Cassandra vector store. The store is created and filled at once, and is then queried to retrieve relevant parts of the indexed text, which are then stuffed into a prompt finally used to answer a question."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "SCxWxjRWl8Dg",
+      "metadata": {
+        "id": "SCxWxjRWl8Dg"
+      },
+      "outputs": [],
+      "source": [
+        "# Import the needed libraries and declare the LLM model\n",
+        "from langchain.embeddings import OpenAIEmbeddings\n",
+        "from langchain.vectorstores.cassandra import Cassandra\n",
+        "from langchain.document_loaders import TextLoader\n",
+        "from langchain.document_loaders import PyPDFLoader\n",
+        "\n",
+        "# Loop through each file and load it into our vector store\n",
+        "documents = []\n",
+        "for filename in SAMPLEDATA:\n",
+        "  path = os.path.join(os.getcwd(), filename)\n",
+        "\n",
+        "  # Supported file types are pdf and txt\n",
+        "  if filename.endswith(\".pdf\"):\n",
+        "    loader = PyPDFLoader(path)\n",
+        "    new_docs = loader.load_and_split()\n",
+        "    print(f\"Processed pdf file: {filename}\")\n",
+        "  elif filename.endswith(\".txt\"):\n",
+        "    loader = TextLoader(path)\n",
+        "    new_docs = loader.load_and_split()\n",
+        "    print(f\"Processed txt file: {filename}\")\n",
+        "  else:\n",
+        "    print(f\"Unsupported file type: {filename}\")\n",
+        "\n",
+        "  if len(new_docs) > 0:\n",
+        "    documents.extend(new_docs)\n",
+        "\n",
+        "cassVStore = Cassandra.from_documents(\n",
+        "  documents=documents,\n",
+        "  embedding=OpenAIEmbeddings(),\n",
+        "  session=session,\n",
+        "  keyspace=ASTRA_DB_KEYSPACE,\n",
+        "  table_name=ASTRA_DB_TABLE_NAME,\n",
+        ")\n",
+        "\n",
+        "# empty the list of file names -- we don't want to accidentally load the same files again\n",
+        "SAMPLEDATA = []\n",
+        "\n",
+        "print(f\"\\nProcessing done.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "pQUQd1uSNe2G",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "pQUQd1uSNe2G",
+        "outputId": "ac074f20-2dbd-4e02-8ec7-b9c4afbe0865"
+      },
+      "outputs": [],
+      "source": [
+        "from cassandra.query import SimpleStatement\n",
+        "\n",
+        "# create a query that returns the 3 rows of the Astra DB table\n",
+        "cqlSelect = SimpleStatement(f\"\"\"SELECT * from {keyspace}.{ASTRA_DB_TABLE_NAME} limit 3;\"\"\")\n",
+        "\n",
+        "rows = session.execute(cqlSelect)\n",
+        "for row_i, row in enumerate(rows):\n",
+        "    print(f'\\nRow {row_i}:')\n",
+        "    print(f'    row_id:      {row.row_id}')\n",
+        "    print(f'    vector: {str(row.vector)[:64]} ...')\n",
+        "    print(f'    body_blob:         {row.body_blob} ...')\n",
+        "\n",
+        "print('\\n...')\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "geA-eXncFwvi",
+      "metadata": {
+        "id": "geA-eXncFwvi"
+      },
+      "source": [
+        "Now let's query our proprietary store."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cEp-I8wd5Abv",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 87
+        },
+        "id": "cEp-I8wd5Abv",
+        "outputId": "1f818fff-2fe9-4a29-cbfa-0e41193f3fbe"
+      },
+      "outputs": [],
+      "source": [
+        "from langchain.indexes.vectorstore import VectorStoreIndexWrapper\n",
+        "\n",
+        "index = VectorStoreIndexWrapper(vectorstore=cassVStore)\n",
+        "query = \"Who is Luchesi?\"\n",
+        "index.query(query,llm=llm)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "S_96yaY45OFw",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        },
+        "id": "S_96yaY45OFw",
+        "outputId": "16f149e4-766f-44b6-f8ea-326153c1fc24"
+      },
+      "outputs": [],
+      "source": [
+        "query = \"What motivates Montresor to seek revenge against Fortunato?\"\n",
+        "index.query(query,llm=llm)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "dg1FUbYoudSr",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "dg1FUbYoudSr",
+        "outputId": "10478b4d-d1d2-4d58-a450-38d045deb239"
+      },
+      "outputs": [],
+      "source": [
+        "# We can query the index for the relevant documents, which act as context for the LLM. \n",
+        "retriever = index.vectorstore.as_retriever(search_kwargs={\n",
+        "    'k': 2, # retrieve 2 documents\n",
+        "})\n",
+        "retriever.get_relevant_documents(\n",
+        "    \"What motivates Montresor to seek revenge against Fortunado?\"\n",
+        ")"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.4"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
Old paths were still pointing to the examples repo. This adds them here and fixes the documentation links (@mendonk please verify that's all the places that need fixing)

This, for now, fixes so they at least have a notebook. Some of the techniques in this notebook(s) are outdated, so I'll clean them up on the next PR. 