### PR TITLE
retry on 504 when delete_collection

### DIFF
--- a/ragstack-e2e-tests/e2e_tests/langchain/test_astra.py
+++ b/ragstack-e2e-tests/e2e_tests/langchain/test_astra.py
@@ -460,19 +460,14 @@ def environment():
 
 
 def close_vector_db(vector_store: VectorStore):
-    try_close_vector_db(vector_store)
-
-def try_close_vector_db(vector_store: VectorStore, max_attempts=5):
-    for attempt in range(max_attempts):
-        try:
-            vector_store.astra_db.delete_collection(vector_store.collection_name)
-            break
-        except requests.HTTPError as e:
-            if e.response.status_code == 504:
-                logging.error(f"Attempt {attempt+1} 504 error while deleting collection {vector_store.collection_name}: {e}")
-            else:
-                logging.error(f"Error while deleting collection {vector_store.collection_name}: {e}")
-                raise e
+    try:
+        vector_store.astra_db.delete_collection(vector_store.collection_name)
+    except requests.HTTPError as e:
+        if e.response.status_code == 504:
+            logging.error(f"Gateway 504 timeout error while deleting collection {vector_store.collection_name}: {e}")
+        else:
+            logging.error(f"Error while deleting collection {vector_store.collection_name}: {e}")
+            raise e
 
 
 def init_embeddings() -> Embeddings:


### PR DESCRIPTION

delete_collection() was in VectorStore class in LC. It probably does NOT make sense to fix their either since this exposes our bug in LC project.
I’m going to add retry delete in the ragstack-ai’s test. I suppose the astrapy repo just throw 504 based on this call raise_for_status()
    def request(self: T) -> API_RESPONSE:
        # Make the raw request to the API
        self.response = self.raw_request()

        # If the response was not successful (non-success error code) raise an error directly
        self.response.raise_for_status()

        # Otherwise, process the successful response
        return self._process_response()