### PR TITLE
tests: temporary disable vertex gemini pro tests

### DIFF
--- a/ragstack-e2e-tests/e2e_tests/langchain/test_compatibility_rag.py
+++ b/ragstack-e2e-tests/e2e_tests/langchain/test_compatibility_rag.py
@@ -260,7 +260,8 @@ def gemini_pro_llm():
 @pytest.mark.parametrize(
     "embedding,llm",
     [
-        ("vertex_gemini_multimodal_embedding", "vertex_gemini_pro_vision_llm"),
+        # disable due to this bug: https://github.com/googleapis/python-aiplatform/issues/3227
+        # ("vertex_gemini_multimodal_embedding", "vertex_gemini_pro_vision_llm"),
         ("vertex_gemini_multimodal_embedding", "gemini_pro_vision_llm"),
     ],
 )

--- a/ragstack-e2e-tests/e2e_tests/llama_index/test_compatibility_rag.py
+++ b/ragstack-e2e-tests/e2e_tests/llama_index/test_compatibility_rag.py
@@ -284,7 +284,7 @@ def gemini_pro_vision_llm():
     "embedding,llm",
     [
         # disable due to this bug: https://github.com/googleapis/python-aiplatform/issues/3227
-        #("vertex_gemini_multimodal_embedding", "vertex_gemini_pro_vision_llm"),
+        # ("vertex_gemini_multimodal_embedding", "vertex_gemini_pro_vision_llm"),
         ("vertex_gemini_multimodal_embedding", "gemini_pro_vision_llm"),
     ],
 )

--- a/ragstack-e2e-tests/e2e_tests/llama_index/test_compatibility_rag.py
+++ b/ragstack-e2e-tests/e2e_tests/llama_index/test_compatibility_rag.py
@@ -283,7 +283,8 @@ def gemini_pro_vision_llm():
 @pytest.mark.parametrize(
     "embedding,llm",
     [
-        ("vertex_gemini_multimodal_embedding", "vertex_gemini_pro_vision_llm"),
+        # disable due to this bug: https://github.com/googleapis/python-aiplatform/issues/3227
+        #("vertex_gemini_multimodal_embedding", "vertex_gemini_pro_vision_llm"),
         ("vertex_gemini_multimodal_embedding", "gemini_pro_vision_llm"),
     ],
 )


### PR DESCRIPTION
They're failing more often. The problem seems in the google-vertex client, I opened this issue: https://github.com/googleapis/python-aiplatform/issues/3227