### PR TITLE
ci: update some plugins

### DIFF
--- a/.github/actions/deploy-slack-report/action.yml
+++ b/.github/actions/deploy-slack-report/action.yml
@@ -44,7 +44,7 @@ runs:
         -n '{"content": $content, "summary": $summary, "commit": $commit, "url": $url, "type": $type}'  > slack-report.json
       echo "Slack report generated to slack-report.json"
       cat slack-report.json
-  - uses: slackapi/slack-github-action@v1.24.0
+  - uses: slackapi/slack-github-action@v1.25.0
     with:
       payload-file-path: "./slack-report.json"
     env:

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -15,7 +15,7 @@ runs:
         cache: "pip"
 
     - name: "Install tox"
-      bash: shell
+      shell: bash
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox poetry

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,0 +1,20 @@
+name: Setup Python
+description: Setup Python and pip/tox/poetry
+
+inputs:
+  python-version:
+    default: 3.11
+    description: 'Astra DB application token'
+runs:
+  using: "composite"
+  steps:
+    - name: "Setup: Python ${{ inputs.python-version }}"
+      uses: actions/setup-python@v5
+      with:
+        python-version: "${{ inputs.python-version }}"
+        cache: "pip"
+
+    - name: "Install tox"
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox poetry

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -15,6 +15,7 @@ runs:
         cache: "pip"
 
     - name: "Install tox"
+      bash: shell
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox poetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       notebooks: ${{ steps.filter.outputs.notebooks }}
       e2e_tests: ${{ steps.filter.outputs.e2e_tests }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build docker image
         uses: ./.github/actions/build-deploy-docker-image
         with:
@@ -71,18 +71,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Setup: Python 3.11"
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-          cache: "pip"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
+        uses: ./.github/actions/setup-python
 
       - name: Run ragstack-ai unit tests
         run: |
@@ -129,18 +121,10 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Setup: Python 3.11"
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-          cache: "pip"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
+        uses: ./.github/actions/setup-python
 
       - name: Setup AstraDB
         uses: ./.github/actions/setup-astra-db
@@ -208,7 +192,7 @@ jobs:
         uses: ./.github/actions/deploy-slack-report
         with:
           from-report-file: ragstack-e2e-tests/failed-tests-report.txt
-          type: "RAGStack Tests"
+          type: "RAGStack dev Tests"
           outcome: ${{ steps.e2e-tests.outcome }}
           commit-url: "https://github.com/datastax/ragstack-ai/commits/${{ steps.commit-ref.outputs.commit-ref }}"
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/clean-astra-env.yml
+++ b/.github/workflows/clean-astra-env.yml
@@ -21,7 +21,7 @@ jobs:
             env: DEV
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Clean DBs
         env:
           TERM: linux

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -16,7 +16,7 @@ jobs:
     name: Docker deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/langchain-master-daily.yml
+++ b/.github/workflows/langchain-master-daily.yml
@@ -40,20 +40,11 @@ jobs:
     steps:
       - name: Check out the repo
         if: ${{ !matrix.skip }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: 'Setup: Python 3.11'
+      - name: "Setup: Python 3.11"
         if: ${{ !matrix.skip }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Install dependencies
-        if: ${{ !matrix.skip }}
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
+        uses: ./.github/actions/setup-python
 
       - name: Setup AstraDB
         uses: ./.github/actions/setup-astra-db

--- a/.github/workflows/llamaindex-main-daily.yml
+++ b/.github/workflows/llamaindex-main-daily.yml
@@ -40,20 +40,11 @@ jobs:
     steps:
       - name: Check out the repo
         if: ${{ !matrix.skip }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: 'Setup: Python 3.11'
+      - name: "Setup: Python 3.11"
         if: ${{ !matrix.skip }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Install dependencies
-        if: ${{ !matrix.skip }}
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
+        uses: ./.github/actions/setup-python
 
       - name: Setup AstraDB
         uses: ./.github/actions/setup-astra-db

--- a/.github/workflows/ragstack-ai-latest.yml
+++ b/.github/workflows/ragstack-ai-latest.yml
@@ -40,20 +40,11 @@ jobs:
     steps:
       - name: Check out the repo
         if: ${{ !matrix.skip }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: 'Setup: Python 3.11'
-        uses: actions/setup-python@v4
+      - name: "Setup: Python 3.11"
         if: ${{ !matrix.skip }}
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Install dependencies
-        if: ${{ !matrix.skip }}
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
+        uses: ./.github/actions/setup-python
 
       - name: Setup AstraDB
         uses: ./.github/actions/setup-astra-db

--- a/.github/workflows/release-ragstack.yml
+++ b/.github/workflows/release-ragstack.yml
@@ -12,17 +12,10 @@ jobs:
     permissions: write-all
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
-      - name: 'Setup: Python 3.11'
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-      - name: Install Poetry
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install poetry
+        uses: actions/checkout@v4
+
+      - name: "Setup: Python 3.11"
+        uses: ./.github/actions/setup-python
 
       - name: Release
         uses: ./.github/actions/release-package

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -12,22 +12,13 @@ jobs:
     name: Run benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
-          
-          
+      - name: "Setup: Python 3.11"
+        uses: ./.github/actions/setup-python
+
       - name: Run
         env:
           OPEN_AI_KEY: "${{ secrets.E2E_TESTS_OPEN_AI_KEY }}"

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -18,15 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Run Snyk to check for vulnerabilities
         id: snyk
         uses: ./.github/actions/snyk-python-3.11
         with:
           token: ${{ secrets.SNYK_TOKEN }}
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
+
+      - name: "Setup: Python 3.11"
+        if: always()
+        uses: ./.github/actions/setup-python
+
       - name: Process Snyk report
         if: always()
         run: python ./scripts/parse-snyk-report.py snyk-vuln.json snyk-report.txt
@@ -43,18 +46,11 @@ jobs:
 
       - name: Prepare report for Slack
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-        uses: ./.github/actions/generate-slack-report
+        uses: ./.github/actions/deploy-slack-report
         with:
           from-report-file: snyk-report.txt
-          output-file: slack-report.json
           type: "RAGStack Security Scan"
           outcome: ${{ steps.snyk.outcome }}
           commit-url: "https://github.com/datastax/ragstack-ai/commits/${{ steps.commit-ref.outputs.commit-ref }}"
-      - name: Dump report on Slack
-        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          payload-file-path: "./slack-report.json"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -12,15 +12,13 @@ jobs:
     name: Update API reference
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
+      - name: "Setup: Python 3.11"
+        if: ${{ !matrix.skip }}
+        uses: ./.github/actions/setup-python
+
       - name: Update API reference
         uses: ./.github/actions/deploy-api-reference
         with:


### PR DESCRIPTION
Fix the following warnings
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, slackapi/slack-github-action@v1.24.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```