### PR TITLE
[tests] Moves lint to separate job (and formats yml)

### DIFF
--- a/.github/actions/add-report-to-github-summary/action.yml
+++ b/.github/actions/add-report-to-github-summary/action.yml
@@ -1,39 +1,41 @@
-name: 'Add report to GitHub summary'
-description: 'Add report to GitHub summary'
+name: "Add report to GitHub summary"
+description: "Add report to GitHub summary"
+
 inputs:
   all:
     default: "true"
-    description: 'Whether to report all tests'
+    description: "Whether to report all tests"
   langchain:
     default: "false"
-    description: 'Whether to report LangChain tests'
+    description: "Whether to report LangChain tests"
   llama-index:
     default: "false"
-    description: 'Whether to report LLamaIndex tests'
+    description: "Whether to report LLamaIndex tests"
+
 runs:
   using: "composite"
   steps:
-  - shell: bash
-    run: |
-      set -e
-      write_report() {
-        local report_file=$1
-        local report_type=$2
-        if [ -f "$report_file" ]; then
-          echo "## $report_type" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "$(cat $report_file)" >> $GITHUB_STEP_SUMMARY
-          echo "Report $report_type added to the summary"
-        else
-          echo "Report $report_type not found"
+    - shell: bash
+      run: |
+        set -e
+        write_report() {
+          local report_file=$1
+          local report_type=$2
+          if [ -f "$report_file" ]; then
+            echo "## $report_type" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "$(cat $report_file)" >> $GITHUB_STEP_SUMMARY
+            echo "Report $report_type added to the summary"
+          else
+            echo "Report $report_type not found"
+          fi
+        }
+        if [ "${{ inputs.all }}" == "true" ]; then
+          write_report ragstack-e2e-tests/all-tests-report.txt "All tests" 
         fi
-      }
-      if [ "${{ inputs.all }}" == "true" ]; then
-        write_report ragstack-e2e-tests/all-tests-report.txt "All tests" 
-      fi
-      if [ "${{ inputs.langchain }}" == "true" ]; then
-        write_report ragstack-e2e-tests/langchain-tests-report.txt "LangChain tests"
-      fi
-      if [ "${{ inputs.llama-index }}" == "true" ]; then
-        write_report ragstack-e2e-tests/llamaindex-tests-report.txt "Llama Index tests"
-      fi
+        if [ "${{ inputs.langchain }}" == "true" ]; then
+          write_report ragstack-e2e-tests/langchain-tests-report.txt "LangChain tests"
+        fi
+        if [ "${{ inputs.llama-index }}" == "true" ]; then
+          write_report ragstack-e2e-tests/llamaindex-tests-report.txt "Llama Index tests"
+        fi

--- a/.github/actions/build-deploy-docker-image/action.yml
+++ b/.github/actions/build-deploy-docker-image/action.yml
@@ -1,22 +1,24 @@
 name: "Build and deploy Docker image"
 description: "Build and deploy Docker image"
+
 inputs:
   github-token:
     required: true
-    description: 'Github token'
+    description: "Github token"
   ragstack-version:
     required: true
-    description: 'Ragstack version'
+    description: "Ragstack version"
   docker-tag:
     required: false
-    description: 'Docker tag to use'
+    description: "Docker tag to use"
   push:
     default: "false"
-    description: 'Whether to push the image or not'
+    description: "Whether to push the image or not"
+
 runs:
   using: "composite"
   steps:
-    - name: 'Login to GitHub Container Registry'
+    - name: "Login to GitHub Container Registry"
       uses: docker/login-action@v3
       with:
         registry: ghcr.io

--- a/.github/actions/cleanup-astra-db/action.yml
+++ b/.github/actions/cleanup-astra-db/action.yml
@@ -4,20 +4,21 @@ description: Delete a database in Astra DB
 inputs:
   astra-token:
     required: true
-    description: 'Astra DB application token'
+    description: "Astra DB application token"
   db-name:
     required: true
-    description: 'Astra DB database name'
+    description: "Astra DB database name"
   env:
     required: true
-    description: 'Astra DB env'
+    description: "Astra DB env"
+
 runs:
   using: "composite"
   steps:
-  - name: Delete database
-    shell: bash
-    env:
-      TERM: linux
-    run: |
-      (curl -Ls "https://dtsx.io/get-astra-cli" | bash) || true
-      /home/runner/.astra/cli/astra db delete "${{ inputs.db-name }}" --token ${{ inputs.astra-token }} --env "${{ inputs.env }}" --async
+    - name: Delete database
+      shell: bash
+      env:
+        TERM: linux
+      run: |
+        (curl -Ls "https://dtsx.io/get-astra-cli" | bash) || true
+        /home/runner/.astra/cli/astra db delete "${{ inputs.db-name }}" --token ${{ inputs.astra-token }} --env "${{ inputs.env }}" --async

--- a/.github/actions/deploy-api-reference/action.yml
+++ b/.github/actions/deploy-api-reference/action.yml
@@ -4,7 +4,8 @@ description: Build and deploy API reference
 inputs:
   ragstack-version:
     required: true
-    description: 'RAGStack version'
+    description: "RAGStack version"
+
 runs:
   using: "composite"
   steps:

--- a/.github/actions/deploy-slack-report/action.yml
+++ b/.github/actions/deploy-slack-report/action.yml
@@ -1,57 +1,59 @@
-name: 'Deploy Slack report'
-description: 'Deploy a report to Slack'
+name: "Deploy Slack report"
+description: "Deploy a report to Slack"
+
 inputs:
   from-report-file:
     required: true
-    description: 'File to read the report from'
+    description: "File to read the report from"
   type:
     required: true
-    description: 'Type of the report'
+    description: "Type of the report"
   outcome:
     required: true
-    description: 'Outcome of the test run'
+    description: "Outcome of the test run"
   commit-url:
     required: true
-    description: 'Github commit url'
+    description: "Github commit url"
   slack-webhook-url:
     required: true
-    description: 'Slack webhook url'
+    description: "Slack webhook url"
+
 runs:
   using: "composite"
   steps:
-  - shell: bash
-    id: prepare
-    run: |
-      from_file=${{ inputs.from-report-file }}
-      
-      if [ -f "$from_file" ]; then
-        echo "Report found"
-      else
-        echo "Report NOT found"
-        echo "send-report=false" >> $GITHUB_OUTPUT
-        pwd
-        ls -la .
-        touch $from_file
-        exit 0
-      fi
-      echo "send-report=true" >> $GITHUB_OUTPUT
-      if [ "${{ inputs.outcome }}" != "success" ]; then
-        summary="FAILED ❌"
-      else
-        summary="PASSED ✅"
-      fi
-      jq \
-        --arg content "$(cat $from_file)" \
-        --arg summary "$summary" \
-        --arg commit "${{ inputs.commit-url }}" \
-        --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-        --arg type "${{ inputs.type }}" \
-        -n '{"content": $content, "summary": $summary, "commit": $commit, "url": $url, "type": $type}'  > slack-report.json
-      echo "Slack report generated to slack-report.json"
-      cat slack-report.json
-  - uses: slackapi/slack-github-action@v1.25.0
-    if: ${{ steps.prepare.outputs.send-report == 'true' }}
-    with:
-      payload-file-path: "./slack-report.json"
-    env:
-      SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
+    - shell: bash
+      id: prepare
+      run: |
+        from_file=${{ inputs.from-report-file }}
+
+        if [ -f "$from_file" ]; then
+          echo "Report found"
+        else
+          echo "Report NOT found"
+          echo "send-report=false" >> $GITHUB_OUTPUT
+          pwd
+          ls -la .
+          touch $from_file
+          exit 0
+        fi
+        echo "send-report=true" >> $GITHUB_OUTPUT
+        if [ "${{ inputs.outcome }}" != "success" ]; then
+          summary="FAILED ❌"
+        else
+          summary="PASSED ✅"
+        fi
+        jq \
+          --arg content "$(cat $from_file)" \
+          --arg summary "$summary" \
+          --arg commit "${{ inputs.commit-url }}" \
+          --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          --arg type "${{ inputs.type }}" \
+          -n '{"content": $content, "summary": $summary, "commit": $commit, "url": $url, "type": $type}'  > slack-report.json
+        echo "Slack report generated to slack-report.json"
+        cat slack-report.json
+    - uses: slackapi/slack-github-action@v1.25.0
+      if: ${{ steps.prepare.outputs.send-report == 'true' }}
+      with:
+        payload-file-path: "./slack-report.json"
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}

--- a/.github/actions/deploy-testspace-report/action.yml
+++ b/.github/actions/deploy-testspace-report/action.yml
@@ -1,84 +1,85 @@
-name: 'Testspace deploy'
-description: 'Setup Testspace client to publish CI results from workflow to Dashboard; report flaky tests, metrics, graphs, and analytics'
+name: "Testspace deploy"
+description: "Setup Testspace client to publish CI results from workflow to Dashboard; report flaky tests, metrics, graphs, and analytics"
 branding:
   color: green
   icon: terminal
+
 inputs:
-    report-type:
-      required: true
-    token:
-        required: true
-        description: "Testspace token"
-    space:
-        required: true
-        description: "Testspace project's space"
-    report-file:
-        required: true
-        description: "Report to upload"
-    repository:
-        default: "ragstack-ai"
-        description: "Testspace repository"
-    project:
-        default: "RAGStack"
-        description: "Testspace project"
+  report-type:
+    description: "Type of report to generate"
+    required: true
+  token:
+    required: true
+    description: "Testspace token"
+  space:
+    required: true
+    description: "Testspace project's space"
+  report-file:
+    required: true
+    description: "Report to upload"
+  repository:
+    default: "ragstack-ai"
+    description: "Testspace repository"
+  project:
+    default: "RAGStack"
+    description: "Testspace project"
 
 runs:
-    using: 'composite'
-    steps:
-
-      - run: |
-          base_url=https://testspace-client.s3.amazonaws.com
-          version=""
-          case `uname -s` in
-            Linux)
-              folder=$HOME/bin
-              mkdir -p $folder
-              arch=`uname -m`
-              if [ "$arch" != "x86_64" ]; then version="-${arch}${version}"; fi
-              curl -fsSL ${base_url}/testspace-linux${version}.tgz | tar -zxvf- -C $RUNNER_TEMP
-              cp -f -p -u $RUNNER_TEMP/testspace $folder
-              ;;
-            Darwin)
-              folder=$HOME/bin
-              mkdir -p $folder
-              curl -fsSL ${base_url}/testspace-darwin${version}.tgz | tar -zxvf- -C $RUNNER_TEMP
-              rsync -t -u $RUNNER_TEMP/testspace $folder
-              ;;
-            *) # Windows
-              folder=$LOCALAPPDATA\Programs\testspace
-              mkdir -p "$folder"
-              curl -OsSL ${base_url}/testspace-windows${version}.zip
-              unzip -q -o testspace-windows${version}.zip -d $RUNNER_TEMP
-              rm testspace-windows${version}.zip
-              cp -f -p -u $RUNNER_TEMP/testspace.exe "$folder"
-              ;;
-          esac
-          echo "$folder" >> $GITHUB_PATH
-        shell: bash
-      - run: |
-          if [ -e "${{ inputs.report-file }}" ]; then
-            python ./scripts/generate-testspace-report.py ${{ inputs.report-type }} "${{ inputs.report-file }}" testspace-report.xml
-          else
-            echo "Skipping testspace report generation as ${{ inputs.report-file }} does not exist"
-          fi
-        shell: bash
-        env:
-          TESTSPACE_REPORT_GITHUB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      - run: |
-          if [ -f "${{ inputs.report-file }}" ]; then
-            echo "Original report was:"
-            cat "${{ inputs.report-file }}"
-          elif [ -d "${{ inputs.report-file }}" ]; then
-            echo "Original report was a directory"
-          else
-            echo "Skipping testspace report generation as ${{ inputs.report-file }} does not exist"
-          fi
-          file=testspace-report.xml
-          if [ -f "$file" ]; then
-            echo "Uploading $file to testspace"
-            cat $file
-            testspace testspace-report.xml "${{ inputs.token }}@${{ inputs.repository }}.testspace.com/${{ inputs.project }}/${{ inputs.space }}"
-          else
-            echo "Skipping testspace upload as $file does not exist"
-          fi
-        shell: bash
+  using: "composite"
+  steps:
+    - run: |
+        base_url=https://testspace-client.s3.amazonaws.com
+        version=""
+        case `uname -s` in
+          Linux)
+            folder=$HOME/bin
+            mkdir -p $folder
+            arch=`uname -m`
+            if [ "$arch" != "x86_64" ]; then version="-${arch}${version}"; fi
+            curl -fsSL ${base_url}/testspace-linux${version}.tgz | tar -zxvf- -C $RUNNER_TEMP
+            cp -f -p -u $RUNNER_TEMP/testspace $folder
+            ;;
+          Darwin)
+            folder=$HOME/bin
+            mkdir -p $folder
+            curl -fsSL ${base_url}/testspace-darwin${version}.tgz | tar -zxvf- -C $RUNNER_TEMP
+            rsync -t -u $RUNNER_TEMP/testspace $folder
+            ;;
+          *) # Windows
+            folder=$LOCALAPPDATA\Programs\testspace
+            mkdir -p "$folder"
+            curl -OsSL ${base_url}/testspace-windows${version}.zip
+            unzip -q -o testspace-windows${version}.zip -d $RUNNER_TEMP
+            rm testspace-windows${version}.zip
+            cp -f -p -u $RUNNER_TEMP/testspace.exe "$folder"
+            ;;
+        esac
+        echo "$folder" >> $GITHUB_PATH
+      shell: bash
+    - run: |
+        if [ -e "${{ inputs.report-file }}" ]; then
+          python ./scripts/generate-testspace-report.py ${{ inputs.report-type }} "${{ inputs.report-file }}" testspace-report.xml
+        else
+          echo "Skipping testspace report generation as ${{ inputs.report-file }} does not exist"
+        fi
+      shell: bash
+      env:
+        TESTSPACE_REPORT_GITHUB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    - run: |
+        if [ -f "${{ inputs.report-file }}" ]; then
+          echo "Original report was:"
+          cat "${{ inputs.report-file }}"
+        elif [ -d "${{ inputs.report-file }}" ]; then
+          echo "Original report was a directory"
+        else
+          echo "Skipping testspace report generation as ${{ inputs.report-file }} does not exist"
+        fi
+        file=testspace-report.xml
+        if [ -f "$file" ]; then
+          echo "Uploading $file to testspace"
+          cat $file
+          testspace testspace-report.xml "${{ inputs.token }}@${{ inputs.repository }}.testspace.com/${{ inputs.project }}/${{ inputs.space }}"
+        else
+          echo "Skipping testspace upload as $file does not exist"
+        fi
+      shell: bash

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -9,4 +9,4 @@ runs:
     - name: Lint
       shell: bash
       run: |
-        tox -e lint
+        tox -c ragstack-e2e-tests -e lint

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,0 +1,12 @@
+name: Lint
+description: runs linters
+
+runs:
+  using: composite
+  steps:
+    - name: "Setup Python and Tox"
+      uses: ./.github/actions/setup-python
+    - name: Lint
+      shell: bash
+      run: |
+        tox -e lint

--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -1,19 +1,21 @@
-name: 'Release package'
-description: 'Build and release a package on PyPI'
+name: "Release package"
+description: "Build and release a package on PyPI"
+
 inputs:
   package-directory:
     required: true
-    description: 'Package directory'
+    description: "Package directory"
   pypi-token:
     required: true
-    description: 'PyPI token'
+    description: "PyPI token"
   pypi-test-token:
     required: true
-    description: 'PyPI token'
+    description: "PyPI token"
   pypi-use-test-release:
     required: false
     default: "false"
-    description: 'Whether to release to TestPyPI or PyPI'
+    description: "Whether to release to TestPyPI or PyPI"
+
 runs:
   using: "composite"
   steps:
@@ -28,13 +30,13 @@ runs:
       id: pypi-url
       shell: bash
       run: |
-          if [ "${{ inputs.pypi-use-test-release }}" == "true" ]; then
-            echo "pypi-url=https://test.pypi.org/legacy/" >> $GITHUB_OUTPUT
-            echo "password=${{ inputs.pypi-test-token }}" >> $GITHUB_OUTPUT
-          else
-            echo "pypi-url=https://pypi.org/legacy/" >> $GITHUB_OUTPUT
-            echo "password=${{ inputs.pypi-token }}" >> $GITHUB_OUTPUT
-          fi
+        if [ "${{ inputs.pypi-use-test-release }}" == "true" ]; then
+          echo "pypi-url=https://test.pypi.org/legacy/" >> $GITHUB_OUTPUT
+          echo "password=${{ inputs.pypi-test-token }}" >> $GITHUB_OUTPUT
+        else
+          echo "pypi-url=https://pypi.org/legacy/" >> $GITHUB_OUTPUT
+          echo "password=${{ inputs.pypi-token }}" >> $GITHUB_OUTPUT
+        fi
 
     - name: Publish package to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/actions/scan-docker-image/action.yml
+++ b/.github/actions/scan-docker-image/action.yml
@@ -1,19 +1,21 @@
 name: "Scan Docker image"
 description: "Scan Docker image"
+
 inputs:
   github-token:
     required: true
-    description: 'Github token'
+    description: "Github token"
   docker-tag:
     required: true
-    description: 'Docker tag'
+    description: "Docker tag"
   snyk-token:
     required: true
-    description: 'Snyk token'
+    description: "Snyk token"
+
 runs:
   using: "composite"
   steps:
-    - name: 'Login to GitHub Container Registry'
+    - name: "Login to GitHub Container Registry"
       uses: docker/login-action@v3
       with:
         registry: ghcr.io

--- a/.github/actions/setup-astra-db/action.yml
+++ b/.github/actions/setup-astra-db/action.yml
@@ -4,19 +4,19 @@ description: Setup a new database in Astra DB
 inputs:
   astra-token:
     required: true
-    description: 'Astra DB application token'
+    description: "Astra DB application token"
   db-name:
     required: true
-    description: 'Astra DB database name'
+    description: "Astra DB database name"
   env:
     required: true
-    description: 'Astra DB env'
+    description: "Astra DB env"
   region:
     required: true
-    description: 'Astra DB region'
+    description: "Astra DB region"
   cloud:
     required: true
-    description: 'Astra DB cloud'
+    description: "Astra DB cloud"
 
 outputs:
   db_endpoint:
@@ -25,34 +25,35 @@ outputs:
   db_id:
     description: "Database ID"
     value: ${{ steps.db-setup.outputs.db_id }}
+
 runs:
   using: "composite"
   steps:
-  - name: Create a new database
-    shell: bash
-    id: db-setup
-    env:
-      TERM: linux
-    run: |
-      set -x
-      (curl -Ls "https://dtsx.io/get-astra-cli" | bash) || true 
-      /home/runner/.astra/cli/astra db create -v "${{ inputs.db-name }}" \
-        --env "${{ inputs.env }}" \
-        -k default_keyspace \
-        --token "${{ inputs.astra-token }}" \
-        --vector \
-        --region "${{ inputs.region }}" \
-        --cloud "${{ inputs.cloud }}" \
-        --timeout 600
-      
-      describe_out=$(/home/runner/.astra/cli/astra db describe "${{ inputs.db-name }}" --token "${{ inputs.astra-token }}" --env "${{ inputs.env }}" -o json)
-      database_id=$(echo "$describe_out" | jq -r '.data.id')
-      echo "Found database id: $database_id"
-      domain="astra"
-      if [ "${{ inputs.env }}" == "DEV" ]; then
-        domain="astra-dev"
-      fi
-      db_endpoint="https://${database_id}-${{ inputs.region }}.apps.${domain}.datastax.com"
-      echo "Database endpoint: $db_endpoint"
-      echo "db_endpoint=$db_endpoint" >> $GITHUB_OUTPUT
-      echo "db_id=$database_id" >> $GITHUB_OUTPUT
+    - name: Create a new database
+      shell: bash
+      id: db-setup
+      env:
+        TERM: linux
+      run: |
+        set -x
+        (curl -Ls "https://dtsx.io/get-astra-cli" | bash) || true 
+        /home/runner/.astra/cli/astra db create -v "${{ inputs.db-name }}" \
+          --env "${{ inputs.env }}" \
+          -k default_keyspace \
+          --token "${{ inputs.astra-token }}" \
+          --vector \
+          --region "${{ inputs.region }}" \
+          --cloud "${{ inputs.cloud }}" \
+          --timeout 600
+
+        describe_out=$(/home/runner/.astra/cli/astra db describe "${{ inputs.db-name }}" --token "${{ inputs.astra-token }}" --env "${{ inputs.env }}" -o json)
+        database_id=$(echo "$describe_out" | jq -r '.data.id')
+        echo "Found database id: $database_id"
+        domain="astra"
+        if [ "${{ inputs.env }}" == "DEV" ]; then
+          domain="astra-dev"
+        fi
+        db_endpoint="https://${database_id}-${{ inputs.region }}.apps.${domain}.datastax.com"
+        echo "Database endpoint: $db_endpoint"
+        echo "db_endpoint=$db_endpoint" >> $GITHUB_OUTPUT
+        echo "db_id=$database_id" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -4,7 +4,7 @@ description: Setup Python and pip/tox/poetry
 inputs:
   python-version:
     default: "3.11"
-    description: 'Python version'
+    description: "Python version"
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -5,6 +5,7 @@ inputs:
   python-version:
     default: "3.11"
     description: "Python version"
+
 runs:
   using: "composite"
   steps:

--- a/.github/actions/snyk-python-3.11/action.yml
+++ b/.github/actions/snyk-python-3.11/action.yml
@@ -3,13 +3,15 @@
 
 name: "Snyk Python"
 description: "Check your Python application for vulnerabilties using Snyk"
+
 inputs:
   token:
     required: true
-    description: 'Snyk token'
+    description: "Snyk token"
   args:
     required: false
-    description: 'Additional arguments to pass to Snyk'
+    description: "Additional arguments to pass to Snyk"
+
 runs:
   using: "docker"
   image: "docker://snyk/snyk:python-3.11"
@@ -19,9 +21,9 @@ runs:
     SNYK_INTEGRATION_VERSION: python
     SNYK_TOKEN: "${{ inputs.token }}"
   args:
-  - snyk
-  - test
-  - --severity-threshold=high
-  - --json-file-output=snyk-vuln.json
-  - --print-deps
-  - ${{ inputs.args || '' }}
+    - snyk
+    - test
+    - --severity-threshold=high
+    - --json-file-output=snyk-vuln.json
+    - --print-deps
+    - ${{ inputs.args || '' }}

--- a/.github/workflows/_run_e2e_tests.yml
+++ b/.github/workflows/_run_e2e_tests.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       title:
-        description: 'Title'
+        description: "Title"
         required: true
         type: string
       suite-name:
@@ -15,15 +15,15 @@ on:
         type: boolean
         default: false
       astradb:
-        description: 'Whether to use AstraDB or not'
+        description: "Whether to use AstraDB or not"
         required: true
         type: boolean
       astradb-token-secret-name:
-        description: 'AstraDB token'
+        description: "AstraDB token"
         required: false
         type: string
       astradb-env:
-        description: 'AstraDB env'
+        description: "AstraDB env"
         type: string
         required: false
       astradb-region:
@@ -31,27 +31,25 @@ on:
         required: false
         type: string
       astradb-cloud:
-        description: 'AstraDB cloud'
+        description: "AstraDB cloud"
         required: false
         type: string
       vector-database-type:
-        description: 'Vector database type'
+        description: "Vector database type"
         required: true
         type: string
       deploy-to-slack:
-        description: 'Whether to deploy to Slack or not'
+        description: "Whether to deploy to Slack or not"
         default: true
         type: boolean
       deploy-to-testspace:
-        description: 'Whether to deploy to TestSpace or not'
+        description: "Whether to deploy to TestSpace or not"
         default: false
         type: boolean
       testspace-space:
-        description: 'TestSpace space to deploy to'
+        description: "TestSpace space to deploy to"
         required: false
         type: string
-
-
 
 jobs:
   tests:
@@ -140,7 +138,7 @@ jobs:
           if [ "${{ inputs.suite-name == 'ragstack' }}" == "true" ]; then
             commit_ref=$(git rev-parse --short HEAD)
             echo "commit-url=https://github.com/datastax/ragstack-ai/commits/${commit_ref}" >> $GITHUB_OUTPUT
-          
+
           elif [ "${{ inputs.suite-name == 'langchain' }}" == "true" ]; then
             commit_ref=$(grep resolved_reference ragstack-e2e-tests/poetry.lock | awk -F'"' '{print $2}' | head -1)
             echo "commit-url=https://github.com/langchain-ai/langchain/commits/${commit_ref}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -18,6 +18,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: run lint
+        uses: ./.github/actions/lint
+
   preconditions:
     name: Preconditions
     runs-on: ubuntu-latest
@@ -36,7 +43,11 @@ jobs:
 
   ragstack-dev-dse-tests:
     name: "RAGStack dev / DSE"
+<<<<<<< HEAD
     needs: [ "preconditions" ]
+=======
+    needs: ["preconditions", "lint"]
+>>>>>>> 458d22a1 (add lint)
     if: ${{ needs.preconditions.outputs.is-scheduled == 'true' || needs.preconditions.outputs.e2e_tests == 'true' }}
     uses: ./.github/workflows/_run_e2e_tests.yml
     secrets: inherit
@@ -51,7 +62,11 @@ jobs:
 
   ragstack-dev-astradev-tests:
     name: "RAGStack dev / AstraDB dev"
+<<<<<<< HEAD
     needs: [ "preconditions" ]
+=======
+    needs: ["preconditions", "lint"]
+>>>>>>> 458d22a1 (add lint)
     if: ${{ needs.preconditions.outputs.is-scheduled == 'true' || needs.preconditions.outputs.e2e_tests == 'true' }}
     uses: ./.github/workflows/_run_e2e_tests.yml
     secrets: inherit
@@ -66,11 +81,34 @@ jobs:
       vector-database-type: "astradb"
       deploy-to-slack: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
       deploy-to-testspace: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
+<<<<<<< HEAD
       testspace-space: "RAGStack test suite - RAGStack dev - AstraDB"
+=======
+      testspace-space: "RAGStack test suite - RAGStack dev - AstraDB Dev"
+
+  ragstack-dev-astraprod-tests:
+    name: "RAGStack dev / AstraDB prod"
+    needs: ["preconditions", "lint"]
+    if: ${{ needs.preconditions.outputs.is-scheduled == 'true' || needs.preconditions.outputs.e2e_tests == 'true' }}
+    uses: ./.github/workflows/_run_e2e_tests.yml
+    secrets: inherit
+    with:
+      title: "RAGStack dev / AstraDB prod"
+      suite-name: "ragstack"
+      astradb: true
+      astradb-token-secret-name: "E2E_TESTS_ASTRA_PROD_DB_TOKEN"
+      astradb-env: "PROD"
+      astradb-region: "${{ needs.preconditions.outputs.astradb-prod-region }}"
+      astradb-cloud: "${{ needs.preconditions.outputs.astradb-prod-cloud }}"
+      vector-database-type: "astradb"
+      deploy-to-slack: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
+      deploy-to-testspace: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
+      testspace-space: "RAGStack test suite - RAGStack dev - AstraDB Prod"
+>>>>>>> 458d22a1 (add lint)
 
   langchain-dse-tests:
     name: "LangChain dev / DSE"
-    needs: ["preconditions"]
+    needs: ["preconditions", "lint"]
     if: ${{ needs.preconditions.outputs.is-scheduled == 'true' || needs.preconditions.outputs.e2e_tests == 'true' }}
     uses: ./.github/workflows/_run_e2e_tests.yml
     secrets: inherit
@@ -85,7 +123,7 @@ jobs:
 
   langchain-astradev-tests:
     name: "LangChain dev / AstraDB dev"
-    needs: ["preconditions"]
+    needs: ["preconditions", "lint"]
     if: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
     uses: ./.github/workflows/_run_e2e_tests.yml
     secrets: inherit
@@ -104,7 +142,7 @@ jobs:
 
   llamaindex-dse-tests:
     name: "LLamaIndex dev / DSE"
-    needs: ["preconditions"]
+    needs: ["preconditions", "lint"]
     if: ${{ needs.preconditions.outputs.is-scheduled == 'true' || needs.preconditions.outputs.e2e_tests == 'true' }}
     uses: ./.github/workflows/_run_e2e_tests.yml
     secrets: inherit
@@ -119,7 +157,7 @@ jobs:
 
   llamaindex-astradev-tests:
     name: "LLamaIndex dev / AstraDB dev"
-    needs: ["preconditions"]
+    needs: ["preconditions", "lint"]
     if: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
     uses: ./.github/workflows/_run_e2e_tests.yml
     secrets: inherit
@@ -138,7 +176,7 @@ jobs:
 
   ragstack-latest-release-dse-tests:
     name: "RAGStack latest / DSE"
-    needs: ["preconditions"]
+    needs: ["preconditions", "lint"]
     if: ${{ needs.preconditions.outputs.is-scheduled == 'true' || needs.preconditions.outputs.e2e_tests == 'true' }}
     uses: ./.github/workflows/_run_e2e_tests.yml
     secrets: inherit
@@ -153,7 +191,7 @@ jobs:
 
   ragstack-latest-release-astradev-tests:
     name: "RAGStack latest / AstraDB dev"
-    needs: ["preconditions"]
+    needs: ["preconditions", "lint"]
     if: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
     uses: ./.github/workflows/_run_e2e_tests.yml
     secrets: inherit

--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch: {}
   schedule:
     # astra dev and dse - every 2 hours
-    - cron: '0 */2 * * *'
+    - cron: "0 */2 * * *"
   pull_request:
     paths-ignore:
       - "scripts/**"
@@ -43,11 +43,7 @@ jobs:
 
   ragstack-dev-dse-tests:
     name: "RAGStack dev / DSE"
-<<<<<<< HEAD
-    needs: [ "preconditions" ]
-=======
     needs: ["preconditions", "lint"]
->>>>>>> 458d22a1 (add lint)
     if: ${{ needs.preconditions.outputs.is-scheduled == 'true' || needs.preconditions.outputs.e2e_tests == 'true' }}
     uses: ./.github/workflows/_run_e2e_tests.yml
     secrets: inherit
@@ -62,11 +58,7 @@ jobs:
 
   ragstack-dev-astradev-tests:
     name: "RAGStack dev / AstraDB dev"
-<<<<<<< HEAD
-    needs: [ "preconditions" ]
-=======
     needs: ["preconditions", "lint"]
->>>>>>> 458d22a1 (add lint)
     if: ${{ needs.preconditions.outputs.is-scheduled == 'true' || needs.preconditions.outputs.e2e_tests == 'true' }}
     uses: ./.github/workflows/_run_e2e_tests.yml
     secrets: inherit
@@ -81,30 +73,7 @@ jobs:
       vector-database-type: "astradb"
       deploy-to-slack: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
       deploy-to-testspace: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
-<<<<<<< HEAD
       testspace-space: "RAGStack test suite - RAGStack dev - AstraDB"
-=======
-      testspace-space: "RAGStack test suite - RAGStack dev - AstraDB Dev"
-
-  ragstack-dev-astraprod-tests:
-    name: "RAGStack dev / AstraDB prod"
-    needs: ["preconditions", "lint"]
-    if: ${{ needs.preconditions.outputs.is-scheduled == 'true' || needs.preconditions.outputs.e2e_tests == 'true' }}
-    uses: ./.github/workflows/_run_e2e_tests.yml
-    secrets: inherit
-    with:
-      title: "RAGStack dev / AstraDB prod"
-      suite-name: "ragstack"
-      astradb: true
-      astradb-token-secret-name: "E2E_TESTS_ASTRA_PROD_DB_TOKEN"
-      astradb-env: "PROD"
-      astradb-region: "${{ needs.preconditions.outputs.astradb-prod-region }}"
-      astradb-cloud: "${{ needs.preconditions.outputs.astradb-prod-cloud }}"
-      vector-database-type: "astradb"
-      deploy-to-slack: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
-      deploy-to-testspace: ${{ needs.preconditions.outputs.is-scheduled == 'true' }}
-      testspace-space: "RAGStack test suite - RAGStack dev - AstraDB Prod"
->>>>>>> 458d22a1 (add lint)
 
   langchain-dse-tests:
     name: "LangChain dev / DSE"

--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -22,8 +22,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/lint
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Run lint
+        uses: ./.github/actions/lint
 
   preconditions:
     name: Preconditions

--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -22,8 +22,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: run lint
-        uses: ./.github/actions/lint
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/lint
 
   preconditions:
     name: Preconditions

--- a/ragstack-e2e-tests/tox.ini
+++ b/ragstack-e2e-tests/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 no_package = true
 min_version = 4.0
-env_list = lint, py311
+env_list = py311
 
 [testenv]
 description = run e2e tests


### PR DESCRIPTION
Moved `lint` to a prereq job so that e2e will not run if lint fails. 

Also uses `redhat.vscode-yaml` from the vscode RedHat`YAML` extension for formatting of yml (https://github.com/redhat-developer/vscode-yaml/blob/e5a67a112a9a52eb8d8c991bf444fb309b2eb913/README.md) - @nicoloboschi If you have another style preference, I can swap to that. 