### PR TITLE
[ref] use singleton for vector store handler

### DIFF
--- a/ragstack-e2e-tests/e2e_tests/conftest.py
+++ b/ragstack-e2e-tests/e2e_tests/conftest.py
@@ -12,7 +12,6 @@ from e2e_tests.test_utils.cassandra_vector_store_handler import (
 )
 from e2e_tests.test_utils.vector_store_handler import (
     VectorStoreHandler,
-    VectorStoreImplementation,
 )
 from e2e_tests.test_utils import (
     get_required_env as root_get_required_env,
@@ -58,13 +57,11 @@ if vector_database_type not in ["astradb", "local-cassandra"]:
 is_astra = vector_database_type == "astradb"
 
 
-def get_vector_store_handler(
-    implementation: VectorStoreImplementation,
-) -> VectorStoreHandler:
+def get_vector_store_handler() -> VectorStoreHandler:
     if vector_database_type == "astradb":
-        return AstraDBVectorStoreHandler(implementation)
+        return AstraDBVectorStoreHandler()
     elif vector_database_type == "local-cassandra":
-        return CassandraVectorStoreHandler(implementation)
+        return CassandraVectorStoreHandler()
 
 
 failed_report_lines = []

--- a/ragstack-e2e-tests/e2e_tests/langchain/test_astra.py
+++ b/ragstack-e2e-tests/e2e_tests/langchain/test_astra.py
@@ -392,9 +392,9 @@ def test_vector_search_with_metadata(vectorstore: VectorStore):
 
 @pytest.mark.skip
 def test_stress_astra():
-    handler = AstraDBVectorStoreHandler(VectorStoreImplementation.ASTRADB)
+    handler = AstraDBVectorStoreHandler()
     while True:
-        context = handler.before_test()
+        context = handler.before_test(VectorStoreImplementation.ASTRADB)
         logging.info("mocking test")
         vstore = context.new_langchain_vector_store(embedding=MockEmbeddings())
         vstore.add_texts(["hello world, im a document"])
@@ -426,8 +426,8 @@ class MockEmbeddings(Embeddings):
 def vectorstore() -> AstraDB:
     if not is_astra:
         skip_test_due_to_implementation_not_supported("astradb")
-    handler = AstraDBVectorStoreHandler(VectorStoreImplementation.ASTRADB)
-    context = handler.before_test()
+    handler = AstraDBVectorStoreHandler()
+    context = handler.before_test(VectorStoreImplementation.ASTRADB)
     vector_db = context.new_langchain_vector_store(embedding=MockEmbeddings())
     yield vector_db
     handler.after_test()

--- a/ragstack-e2e-tests/e2e_tests/langchain/test_compatibility_rag.py
+++ b/ragstack-e2e-tests/e2e_tests/langchain/test_compatibility_rag.py
@@ -37,16 +37,16 @@ from e2e_tests.test_utils.vector_store_handler import VectorStoreImplementation
 
 @pytest.fixture
 def astra_db():
-    handler = get_vector_store_handler(VectorStoreImplementation.ASTRADB)
-    context = handler.before_test()
+    handler = get_vector_store_handler()
+    context = handler.before_test(VectorStoreImplementation.ASTRADB)
     yield context
     handler.after_test()
 
 
 @pytest.fixture
 def cassandra():
-    handler = get_vector_store_handler(VectorStoreImplementation.CASSANDRA)
-    context = handler.before_test()
+    handler = get_vector_store_handler()
+    context = handler.before_test(VectorStoreImplementation.CASSANDRA)
     yield context
     handler.after_test()
 

--- a/ragstack-e2e-tests/e2e_tests/langchain/test_document_loaders.py
+++ b/ragstack-e2e-tests/e2e_tests/langchain/test_document_loaders.py
@@ -142,8 +142,8 @@ def test_azure_blob_doc_loader():
 def test_astradb_loader() -> None:
     set_current_test_info_document_loader("astradb")
 
-    handler = AstraDBVectorStoreHandler(VectorStoreImplementation.ASTRADB)
-    handler.before_test()
+    handler = AstraDBVectorStoreHandler()
+    handler.before_test(VectorStoreImplementation.ASTRADB)
     astra_ref = handler.astra_ref
 
     collection = handler.default_astra_client.create_collection(astra_ref.collection)

--- a/ragstack-e2e-tests/e2e_tests/langchain_llamaindex/test_astra.py
+++ b/ragstack-e2e-tests/e2e_tests/langchain_llamaindex/test_astra.py
@@ -227,7 +227,7 @@ def test_ingest_langchain_retrieve_llama_index(astra_ref: AstraRef):
 def astra_ref() -> AstraRef:
     if not is_astra:
         skip_test_due_to_implementation_not_supported("astradb")
-    handler = AstraDBVectorStoreHandler(VectorStoreImplementation.ASTRADB)
-    handler.before_test()
+    handler = AstraDBVectorStoreHandler()
+    handler.before_test(VectorStoreImplementation.ASTRADB)
     yield handler.astra_ref
     handler.after_test()

--- a/ragstack-e2e-tests/e2e_tests/llama_index/test_astra.py
+++ b/ragstack-e2e-tests/e2e_tests/llama_index/test_astra.py
@@ -226,8 +226,10 @@ def environment() -> Environment:
     if not is_astra:
         skip_test_due_to_implementation_not_supported("astradb")
     embeddings = MockEmbeddings()
-    handler = AstraDBVectorStoreHandler(VectorStoreImplementation.ASTRADB)
-    vector_db = handler.before_test().new_llamaindex_vector_store(embedding_dimension=3)
+    handler = AstraDBVectorStoreHandler()
+    vector_db = handler.before_test(
+        VectorStoreImplementation.ASTRADB
+    ).new_llamaindex_vector_store(embedding_dimension=3)
     llm = OpenAI(
         api_key=get_required_env("OPEN_AI_KEY"),
         model="gpt-3.5-turbo-16k",

--- a/ragstack-e2e-tests/e2e_tests/llama_index/test_compatibility_rag.py
+++ b/ragstack-e2e-tests/e2e_tests/llama_index/test_compatibility_rag.py
@@ -41,16 +41,16 @@ from e2e_tests.test_utils.vector_store_handler import (
 
 @pytest.fixture
 def astra_db():
-    handler = get_vector_store_handler(VectorStoreImplementation.ASTRADB)
-    context = handler.before_test()
+    handler = get_vector_store_handler()
+    context = handler.before_test(VectorStoreImplementation.ASTRADB)
     yield context
     handler.after_test()
 
 
 @pytest.fixture
 def cassandra():
-    handler = get_vector_store_handler(VectorStoreImplementation.CASSANDRA)
-    context = handler.before_test()
+    handler = get_vector_store_handler()
+    context = handler.before_test(VectorStoreImplementation.CASSANDRA)
     yield context
     handler.after_test()
 

--- a/ragstack-e2e-tests/e2e_tests/test_utils/cassandra_vector_store_handler.py
+++ b/ragstack-e2e-tests/e2e_tests/test_utils/cassandra_vector_store_handler.py
@@ -33,12 +33,15 @@ from e2e_tests.test_utils.vector_store_handler import (
 class CassandraVectorStoreHandler(VectorStoreHandler):
     cassandra_container = None
 
-    def __init__(self, implementation: VectorStoreImplementation) -> None:
-        super().__init__(implementation, [VectorStoreImplementation.CASSANDRA])
+    def __init__(self) -> None:
+        super().__init__([VectorStoreImplementation.CASSANDRA])
         self.cassandra_session = None
         self.test_table_name = None
 
-    def before_test(self) -> VectorStoreTestContext:
+    def before_test(
+        self, implementation: VectorStoreImplementation
+    ) -> VectorStoreTestContext:
+        self.implementation = implementation
         super().check_implementation()
 
         self.test_table_name = "table_" + random_string()

--- a/ragstack-e2e-tests/e2e_tests/test_utils/singleton.py
+++ b/ragstack-e2e-tests/e2e_tests/test_utils/singleton.py
@@ -1,0 +1,25 @@
+from abc import ABCMeta
+
+
+class Singleton(ABCMeta):
+    """
+    Metaclass for creating singletons.
+
+    Note this is not a thread-safe implementation.
+    """
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            instance = super().__call__(*args, **kwargs)
+            cls._instances[cls] = instance
+        else:
+            instance = cls._instances[cls]
+            # Allow reinitialization if the class has the attribute __allow_reinitialization
+            if (
+                hasattr(cls, "__allow_reinitialization")
+                and cls.__allow_reinitialization
+            ):
+                instance.__init__(*args, **kwargs)
+        return instance

--- a/ragstack-e2e-tests/e2e_tests/test_utils/vector_store_handler.py
+++ b/ragstack-e2e-tests/e2e_tests/test_utils/vector_store_handler.py
@@ -12,6 +12,7 @@ from e2e_tests.test_utils import skip_test_due_to_implementation_not_supported
 class VectorStoreImplementation(Enum):
     ASTRADB = "astradb"
     CASSANDRA = "cassandra"
+    UNINITIALIZED = ""
 
 
 class EnhancedVectorStore(ABC):
@@ -51,18 +52,22 @@ class VectorStoreTestContext(ABC):
 class VectorStoreHandler(ABC):
     def __init__(
         self,
-        implementation: VectorStoreImplementation,
         supported_implementations: List[VectorStoreImplementation],
     ):
-        self.implementation = implementation
+        self.implementation = VectorStoreImplementation.UNINITIALIZED
         self.supported_implementations = supported_implementations
 
     def check_implementation(self):
+        if self.implementation == VectorStoreImplementation.UNINITIALIZED:
+            raise ValueError("Implementation not initialized")
+
         if self.implementation not in self.supported_implementations:
             skip_test_due_to_implementation_not_supported(self.implementation.value)
 
     @abstractmethod
-    def before_test(self) -> VectorStoreTestContext:
+    def before_test(
+        self, implementation: VectorStoreImplementation
+    ) -> VectorStoreTestContext:
         pass
 
     def after_test(self):


### PR DESCRIPTION
MyPy work was complaining about this are a bit, so I went on a tangent. Cleans up the singleton handler a bit so it doesn't have to use shared class variables and only calls `init` once. 

Though, this PR doesn't do much actual cleanup aside from that. I think it's a good step and later on can clean up the `VectorStoreImplementation` stuff. 