### PR TITLE
[docs] - Bump API to 0.7.0

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -41,6 +41,7 @@
 * xref:ROOT:changelog.adoc[]
 
 .API Reference
+* https://datastax.github.io/ragstack-ai/api_reference/0.7.0/langchain[0.7.0]
 * https://datastax.github.io/ragstack-ai/api_reference/0.6.0/langchain[0.6.0]
 * https://datastax.github.io/ragstack-ai/api_reference/0.5.0/langchain[0.5.0]
 * https://datastax.github.io/ragstack-ai/api_reference/0.4.0/langchain[0.4.0]

--- a/docs/modules/ROOT/pages/migration.adoc
+++ b/docs/modules/ROOT/pages/migration.adoc
@@ -2,11 +2,12 @@
 
 Migrating existing LangChain or LlamaIndex applications to RAGStack is easy - just change your `requirements.txt` or `pyproject.toml` file to use `ragstack-ai`.
 
-RAGStack contains the below packages as of version `0.6.0`. When RAGStack is installed, these packages are replaced with the stable, tested `ragstack-ai` versions listed here. For the latest list, see xref:ROOT:changelog.adoc[].
+RAGStack contains the below packages as of version `0.7.0`. When RAGStack is installed, these packages are replaced with the stable, tested `ragstack-ai` versions listed here. For the latest list, see xref:ROOT:changelog.adoc[].
 [%autowidth]
 [cols="2*",options="header"]
 |===
 | Library | Version
+
 
 | astrapy
 | >=0.7.0,<0.8.0
@@ -15,13 +16,15 @@ RAGStack contains the below packages as of version `0.6.0`. When RAGStack is ins
 | >=0.1.3,<0.2.0
 
 | langchain
-| https://datastax.github.io/ragstack-ai/api_reference/0.6.0/langchain[==0.1.4]{external-link-icon}
+| https://datastax.github.io/ragstack-ai/api_reference/0.7.0/langchain[==0.1.4]{external-link-icon}
 
 | llama-index
-| ==0.9.34
+| ==0.9.48
 
 | unstructured
 | >=0.10,<0.11
+
+
 |===
 
 == Example LangChain migration

--- a/docs/modules/ROOT/pages/prerequisites.adoc
+++ b/docs/modules/ROOT/pages/prerequisites.adoc
@@ -36,6 +36,10 @@ Automatically created if it doesn't exist.
 | `your-project-name-017849-r83b66711494.json`
 | Credentials for GCP usage.
 See the https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[GCP documentation^]{external-link-icon}.
+
+| LlamaIndex Cloud API key
+| `llx-...`
+| Credentials for LlamaIndex cloud usage.
 |===
 
 If a notebook needs additional dependencies, we'll show you how to install them.


### PR DESCRIPTION
* Bump version in nav and migration
* Add llamaindex cloud API key to prerequisites