### PR TITLE
[Docs] - Remove llama-parse dependency

### DIFF
--- a/docs/modules/examples/pages/llama-parse-astra.adoc
+++ b/docs/modules/examples/pages/llama-parse-astra.adoc
@@ -20,7 +20,7 @@ DB Access Token] with Database Administrator permissions.
 Install the following dependencies:
 [source,python]
 ----
-pip install ragstack-ai llama-parse python-dotenv
+pip install ragstack-ai python-dotenv
 ----
 See the https://docs.datastax.com/en/ragstack/docs/prerequisites.html[Prerequisites] page for more details.
 


### PR DESCRIPTION
Llama-parse is part of ragstack-ai as of 0.7.0, no need to install 