### PR TITLE
Update Llama Parse Notebook for llama 0.10.x

### DIFF
--- a/examples/notebooks/llama-parse-astra.ipynb
+++ b/examples/notebooks/llama-parse-astra.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# First, install the required dependencies\n",
-    "!pip install --quiet llama-index llama-parse llama-index-vector-stores-astra llama-index-llms-openai astrapy"
+    "!pip install --quiet ragstack-ai"
    ]
   },
   {

--- a/examples/notebooks/llama-parse-astra.ipynb
+++ b/examples/notebooks/llama-parse-astra.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-02-13T11:48:33.967092Z",
@@ -35,20 +35,10 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.3.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.0\u001b[0m\r\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython -m pip install --upgrade pip\u001b[0m\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# First, install the required dependencies\n",
-    "!pip install --quiet ragstack-ai"
+    "!pip install --quiet llama-index llama-parse llama-index-vector-stores-astra llama-index-llms-openai astrapy"
    ]
   },
   {
@@ -60,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-02-13T11:59:43.987486Z",
@@ -74,21 +64,7 @@
      "skip-execution"
     ]
    },
-   "outputs": [
-    {
-     "ename": "KeyboardInterrupt",
-     "evalue": "Interrupted by user",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[2], line 11\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[38;5;66;03m# Get all required API keys and parameters\u001b[39;00m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mLLAMA_CLOUD_API_KEY\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m os\u001b[38;5;241m.\u001b[39menviron:\n\u001b[0;32m---> 11\u001b[0m     os\u001b[38;5;241m.\u001b[39menviron[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mLLAMA_CLOUD_API_KEY\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[43mgetpass\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mEnter your Llama Index Cloud API Key:\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m     13\u001b[0m api_endpoint \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39menviron\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mASTRA_DB_API_ENDPOINT\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28minput\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mEnter you Astra DB API Endpoint: \u001b[39m\u001b[38;5;124m\"\u001b[39m))\n\u001b[1;32m     14\u001b[0m token \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39menviron\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mASTRA_DB_API_ENDPOINT\u001b[39m\u001b[38;5;124m\"\u001b[39m, getpass(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mEnter you Astra DB Token: \u001b[39m\u001b[38;5;124m\"\u001b[39m))\n",
-      "File \u001b[0;32m~/.pyenv/versions/nb/lib/python3.11/site-packages/ipykernel/kernelbase.py:1253\u001b[0m, in \u001b[0;36mgetpass\u001b[0;34m(self, prompt, stream)\u001b[0m\n",
-      "File \u001b[0;32m~/.pyenv/versions/nb/lib/python3.11/site-packages/ipykernel/kernelbase.py:1313\u001b[0m, in \u001b[0;36m_input_request\u001b[0;34m(self, prompt, ident, parent, password)\u001b[0m\n",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m: Interrupted by user"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "from getpass import getpass\n",
@@ -101,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-02-13T11:59:49.055038Z",
@@ -130,22 +106,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-02-13T12:00:00.078294Z",
      "start_time": "2024-02-13T11:59:58.410498Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Download complete.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Grab a PDF from Arxiv for indexing\n",
     "import requests \n",
@@ -170,22 +138,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-02-13T12:05:20.215552Z",
      "start_time": "2024-02-13T12:05:15.721697Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Started parsing the file under job_id 50c49013-b7cc-4ed2-8102-499659998b77\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from llama_parse import LlamaParse\n",
     "\n",
@@ -194,25 +154,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-02-13T12:04:28.569279Z",
      "start_time": "2024-02-13T12:04:28.564364Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'                                                    (shifted right)\\n                           Figure 1: The Transformer - model architecture.\\nThe Transformer follows this overall architecture using stacked self-attention and point-wise, fully\\nconnected layers for both the encoder and decoder, shown in the left and right halves of Figure 1,\\nrespectively.\\n3.1   Encoder and Decoder Stacks\\nEncoder:     The encoder is composed of a stack of N = 6 identical layers. Each layer has two\\nsub-layers. The first is a multi-head self-attention mechanism, and the second is a simple, position-\\nwise fully connected feed-forward network. We employ a residual connection [11] around each of\\nthe two sub-layers, followed by layer normalization [1]. That is, the output of each sub-layer is\\nLayerNorm(x + Sublayer(x)), where Sublayer(x) is the function implemented by the sub-layer\\nitself. To facilitate these residual connections, all sub-layers in the model, as well as the embedding\\nlayers, produce outputs of'"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Take a quick look at some of the parsed text from the document:\n",
     "documents[0].get_content()[10000:11000]"
@@ -227,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -238,7 +187,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from llama_index.vector_stores import AstraDBVectorStore\n",
+    "from llama_index.vector_stores.astra import AstraDBVectorStore\n",
     "\n",
     "astra_db_store = AstraDBVectorStore(\n",
     "    token=os.environ[\"ASTRA_DB_TOKEN\"],\n",
@@ -250,12 +199,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.node_parser import SimpleNodeParser\n",
-    "from llama_index.llms import OpenAI\n",
+    "from llama_index.core.node_parser import SimpleNodeParser\n",
     "\n",
     "node_parser = SimpleNodeParser()\n",
     "\n",
@@ -264,26 +212,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index import (\n",
-    "    OpenAIEmbedding,\n",
-    "    VectorStoreIndex,\n",
-    "    StorageContext,\n",
-    "    ServiceContext,\n",
-    ")\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+    "from llama_index.core import VectorStoreIndex, StorageContext\n",
     "\n",
     "storage_context = StorageContext.from_defaults(vector_store=astra_db_store)\n",
     "\n",
-    "service_context = ServiceContext.from_defaults(\n",
-    "    llm=OpenAI(model=\"gpt-3.5-turbo\"), \n",
-    "    embed_model=OpenAIEmbedding(), \n",
-    "    chunk_size=512,\n",
-    ")\n",
-    "\n",
-    "index = VectorStoreIndex(nodes=nodes, storage_context=storage_context)"
+    "index = VectorStoreIndex(\n",
+    "    nodes=nodes,\n",
+    "    storage_context=storage_context,\n",
+    "    embed_model=OpenAIEmbedding(api_key=os.environ[\"OPEN_AI_KEY\"]),\n",
+    ")"
    ]
   },
   {
@@ -295,28 +237,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "query_engine = index.as_query_engine(similarity_top_k=15, service_context=service_context)"
+    "query_engine = index.as_query_engine(similarity_top_k=15)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "***********New LlamaParse+ Basic Query Engine***********\n",
-      "Multi-Head Attention is also known as an attention function that linearly projects the queries, keys and values multiple times with different, learned linear projections to different dimensions. This allows the attention function to be performed in parallel on each of these projected versions of queries, keys and values.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = \"What is Multi-Head Attention also known as?\"\n",
     "\n",
@@ -327,47 +259,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'We used beam search as described in the previous section, but no\\ncheckpoint averaging. We present these results in Table 3.\\nIn Table 3 rows (A), we vary the number of attention heads and the attention key and value dimensions,\\nkeeping the amount of computation constant, as described in Section 3.2.2. While single-head\\nattention is 0.9 BLEU worse than the best setting, quality also drops off with too many heads.\\nIn Table 3 rows (B), we observe that reducing the attention key size dk hurts model quality. This\\nsuggests that determining compatibility is not easy and that a more sophisticated compatibility\\nfunction than dot product may be beneficial. We further observe in rows (C) and (D) that, as expected,\\nbigger models are better, and dropout is very helpful in avoiding over-fitting. In row (E) we replace our\\nsinusoidal positional encoding with learned positional embeddings [9], and observe nearly identical\\nresults to the base model.\\n6.3    English Constituency Parsing\\nTo evaluate if the Transformer can generalize to other tasks we performed experiments on English\\nconstituency parsing. This task presents specific challenges: the output is subject to strong structural\\nconstraints and is significantly longer than the input. Furthermore, RNN sequence-to-sequence\\nmodels have not been able to attain state-of-the-art results in small-data regimes [37].\\nWe trained a 4-layer transformer with dmodel = 1024 on the Wall Street Journal (WSJ) portion of the\\nPenn Treebank [25], about 40K training sentences. We also trained it in a semi-supervised setting,\\nusing the larger high-confidence and BerkleyParser corpora from with approximately 17M sentences\\n[37]. We used a vocabulary of 16K tokens for the WSJ only setting and a vocabulary of 32K tokens\\nfor the semi-supervised setting.\\nWe performed only a small number of experiments to select the dropout, both attention and residual\\n(section 5.4), learning rates and beam size on the Section 22 development set, all other parameters\\nremained unchanged from the English-to-German base translation model. During inference, we\\n                                                             9\\n---\\nTable 4: The Transformer generalizes well to English constituency parsing (Results are on Section 23\\nof WSJ)\\n                          Parser                           Training             WSJ 23 F1\\n            Vinyals & Kaiser el al. (2014) [37]    WSJ only, discriminative         88.3\\n                 Petrov et al. (2006) [29]         WSJ only, discriminative         90.4\\n                   Zhu et al. (2013) [40]          WSJ only, discriminative         90.4\\n                   Dyer et al. (2016) [8]          WSJ only, discriminative         91.7\\n                  Transformer (4 layers)           WSJ only, discriminative         91.3\\n                   Zhu et al. (2013) [40]              semi-supervised              91.3\\n               Huang & Harper (2009) [14]              semi-supervised              91.3\\n               McClosky et al. (2006) [26]             semi-supervised              92.1\\n            Vinyals & Kaiser el al. (2014) [37]        semi-supervised              92.1\\n                  Transformer (4 layers)               semi-supervised              92.7\\n                 Luong et al. (2015) [23]                  multi-task               93.0\\n                   Dyer et al. (2016) [8]                  generative               93.3\\nincreased the maximum output length to input length + 300. We used a beam size of 21 and α = 0.3\\nfor both WSJ only and the semi-supervised setting.\\nOur results in Table 4 show that despite the lack of task-specific tuning our model performs sur-\\nprisingly well, yielding better results than all previously reported models with the exception of the\\nRecurrent Neural Network Grammar [8].\\nIn contrast to RNN sequence-to-sequence models [37], the Transformer outperforms the Berkeley-\\nParser [29] even when training only on the WSJ training set of 40K sentences.\\n7    Conclusion\\nIn this work, we presented the Transformer, the first sequence transduction model based entirely on\\nattention, replacing the recurrent layers most commonly used in encoder-decoder architectures with\\nmulti-headed self-attention.\\nFor translation tasks, the Transformer can be trained significantly faster than architectures based\\non recurrent or convolutional layers.'"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Take a look at one of the source nodes from the response\n",
     "response_1.source_nodes[0].get_content()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "***********New LlamaParse+ Basic Query Engine***********\n",
-      "The context does not provide information about the color of the sky.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Query fails to be answered due to lack of context in Astra DB\n",
-    "query = \"What is the color of the sky?\"\n",
-    "\n",
-    "response_1 = query_engine.query(query)\n",
-    "print(\"\\n***********New LlamaParse+ Basic Query Engine***********\")\n",
-    "print(response_1)"
    ]
   }
  ],
@@ -387,7 +284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This updates the llama parse example notebook to be compatible with the latest 0.10.x release of llama.