### PR TITLE
remove old unstructured dependency

### DIFF
--- a/docs/modules/ROOT/pages/migration.adoc
+++ b/docs/modules/ROOT/pages/migration.adoc
@@ -21,9 +21,6 @@ RAGStack contains the below packages as of version `0.7.0`. When RAGStack is ins
 | llama-index
 | ==0.9.48
 
-| unstructured
-| >=0.10,<0.11
-
 
 |===
 
@@ -201,7 +198,6 @@ tqdm                4.66.1
 typing_extensions   4.9.0
 typing-inspect      0.9.0
 tzdata              2023.3
-unstructured        0.10.30
 urllib3             2.1.0
 wrapt               1.16.0
 xxhash              3.4.1
@@ -395,7 +391,6 @@ tqdm                4.66.1
 typing_extensions   4.9.0
 typing-inspect      0.9.0
 tzdata              2023.4
-unstructured        0.10.30
 urllib3             2.1.0
 wrapt               1.16.0
 yarl                1.9.4

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -63,7 +63,7 @@ Requirement already satisfied: ragstack-ai in ./ragstack-venv/lib/python3.11/sit
 Collecting ragstack-ai
   Downloading ragstack_ai-0.1.1-py3-none-any.whl.metadata (2.4 kB)
 …installing packages…
-Successfully installed astrapy-0.6.1 backoff-2.2.1 chardet-5.2.0 emoji-2.8.0 filetype-1.2.0 h2-4.1.0 hpack-4.0.0 httpcore-1.0.2 httpx-0.25.1 hyperframe-6.0.1 joblib-1.3.2 langdetect-1.0.9 lxml-4.9.3 nltk-3.8.1 python-iso639-2023.6.15 python-magic-0.4.27 ragstack-ai-0.1.1 rapidfuzz-3.5.2 tabulate-0.9.0 unstructured-0.10.30
+Successfully installed astrapy-0.6.1 backoff-2.2.1 chardet-5.2.0 emoji-2.8.0 filetype-1.2.0 h2-4.1.0 hpack-4.0.0 httpcore-1.0.2 httpx-0.25.1 hyperframe-6.0.1 joblib-1.3.2 langdetect-1.0.9 lxml-4.9.3 nltk-3.8.1 python-iso639-2023.6.15 python-magic-0.4.27 ragstack-ai-0.1.1 rapidfuzz-3.5.2 tabulate-0.9.0
 ----
 ======
 +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ packages = [{ include = "ragstack" }]
 python = ">=3.9,<4.0"
 astrapy = "~0.7.0"
 cassio = "~0.1.3"
-unstructured = "^0.10"
 llama-index = { version = "0.9.48", extras = ["langchain"] }
 llama-parse = { version = "0.1.4" }
 langchain = { version = "0.1.4" }

--- a/ragstack-e2e-tests/pyproject.langchain.toml
+++ b/ragstack-e2e-tests/pyproject.langchain.toml
@@ -38,7 +38,6 @@ llama-parse = { version = "0.1.4" }
 astrapy = "~0.7.0"
 # we need this specific feature from cassio: https://github.com/CassioML/cassio/pull/128
 cassio = "~0.1.4"
-unstructured = "^0.10"
 
 [build-system]
 requires = ["poetry-core"]

--- a/ragstack-e2e-tests/pyproject.llamaindex.toml
+++ b/ragstack-e2e-tests/pyproject.llamaindex.toml
@@ -51,7 +51,6 @@ langchain-nvidia-ai-endpoints = { version = "0.0.1" }
 astrapy = "~0.7.0"
 # we need this specific feature from cassio: https://github.com/CassioML/cassio/pull/128
 cassio = "~0.1.4"
-unstructured = "^0.10"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/generate-changelog.py
+++ b/scripts/generate-changelog.py
@@ -5,7 +5,7 @@ except ImportError:
     exit(1)
 import sys
 
-IMPORTANT_DEPENDENCIES = ["langchain", "llama-index", "astrapy", "cassio", "unstructured"]
+IMPORTANT_DEPENDENCIES = ["langchain", "llama-index", "astrapy", "cassio"]
 
 
 def main():

--- a/tests/unit-tests/test_ragstack.py
+++ b/tests/unit-tests/test_ragstack.py
@@ -6,7 +6,6 @@ def test_import():
     import langsmith  # noqa
     import astrapy  # noqa
     import cassio  # noqa
-    import unstructured  # noqa
     import openai  # noqa
     import tiktoken  # noqa
 


### PR DESCRIPTION
This is in preparation of adding the Unstructured API Client to RAGstack.

It seems like this dependency isn't used.

It was originally added here: https://github.com/datastax/ragstack-ai/pull/20