### PR TITLE
draft: generate pyproject.toml files for latest testing

### DIFF
--- a/ragstack-e2e-tests/pyproject.langchain.toml
+++ b/ragstack-e2e-tests/pyproject.langchain.toml
@@ -1,45 +1,18 @@
-[tool.poetry]
-name = "ragstack-e2e-tests"
-version = "0.1.0"
-description = "RAGStack tests"
-license = ""
-authors = ["DataStax"]
-
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12,!=3.9.7"
+# changes required for langchain latest tests
 
 [tool.poetry.group.test.dependencies]
-pytest = "*"
-black = "*"
-ruff = "*"
-google-cloud-aiplatform = "^1.36.4"
-boto3 = "^1.29.6"
-huggingface-hub = "^0.20.3"
-azure-storage-blob = "^12.19.0"
-pillow = "^10.2.0"
-testcontainers = "^3.7.1"
-python-dotenv = "^1.0.1"
-trulens-eval = "^0.21.0"
+#remove from the ragstack-e2e-tests pyproject
+ragstack-ai = ""
 
-# From LangChain optional deps, needed by WebBaseLoader
-beautifulsoup4 = "^4"
-
-langchain = { git = "https://github.com/langchain-ai/langchain.git", branch = "master", subdirectory = "libs/langchain", extras = [
-    "openai",
-] }
-langchain_core = { git = "https://github.com/langchain-ai/langchain.git", branch = "master", subdirectory = "libs/core" }
-langchain_community = { git = "https://github.com/langchain-ai/langchain.git", branch = "master", subdirectory = "libs/community" }
+# grab the following from the latest commit of langchain
+langchain = { git = "https://github.com/langchain-ai/langchain.git", branch = "master", subdirectory = "libs/langchain", extras = [ "openai"] }
+langchain-core = { git = "https://github.com/langchain-ai/langchain.git", branch = "master", subdirectory = "libs/core" }
+langchain-community = { git = "https://github.com/langchain-ai/langchain.git", branch = "master", subdirectory = "libs/community" }
 langchain-openai = { git = "https://github.com/langchain-ai/langchain.git", branch = "master", subdirectory = "libs/partners/openai" }
 langchain-google-genai = { git = "https://github.com/langchain-ai/langchain.git", branch = "master", subdirectory = "libs/partners/google-genai" }
 langchain-google-vertexai = { git = "https://github.com/langchain-ai/langchain.git", branch = "master", subdirectory = "libs/partners/google-vertexai" }
 langchain-nvidia-ai-endpoints = { git = "https://github.com/langchain-ai/langchain.git", branch = "master", subdirectory = "libs/partners/nvidia-ai-endpoints" }
-llama-index = { version = "0.9.48", extras = ["langchain"] }
-llama-parse = { version = "0.1.4" }
-astrapy = "~0.7.0"
-# we need this specific feature from cassio: https://github.com/CassioML/cassio/pull/128
-cassio = "~0.1.4"
-unstructured = "^0.10"
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+# update these to specific versions
+cassio = "~0.1.4"
+google-cloud-aiplatform = "^1.36.4"

--- a/ragstack-e2e-tests/pyproject.llamaindex.toml
+++ b/ragstack-e2e-tests/pyproject.llamaindex.toml
@@ -1,29 +1,10 @@
-[tool.poetry]
-name = "ragstack-e2e-tests"
-version = "0.1.0"
-description = "RAGStack tests"
-license = ""
-authors = ["DataStax"]
-
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12,!=3.9.7"
+# changes required for llama-index latest tests
 
 [tool.poetry.group.test.dependencies]
-pytest = "*"
-black = "*"
-ruff = "*"
-google-cloud-aiplatform = "^1.36.4"
-boto3 = "^1.29.6"
-huggingface-hub = "^0.20.3"
-azure-storage-blob = "^12.19.0"
-pillow = "^10.2.0"
-testcontainers = "^3.7.1"
-python-dotenv = "^1.0.1"
-trulens-eval = "^0.21.0"
+#remove from the ragstack-e2e-tests pyproject
+ragstack-ai = ""
 
-# From LangChain optional deps, needed by WebBaseLoader
-beautifulsoup4 = "^4"
-
+# grab the following from the latest commit at llama-index
 llama-index = { git = "https://github.com/run-llama/llama_index.git", branch = "main" }
 llama-index-embeddings-langchain = { git = "https://github.com/run-llama/llama_index.git", branch = "main", subdirectory = "llama-index-integrations/embeddings/llama-index-embeddings-langchain" }
 llama-index-vector-stores-astra = { git = "https://github.com/run-llama/llama_index.git", branch = "main", subdirectory = "llama-index-integrations/vector_stores/llama-index-vector-stores-astra" }
@@ -38,21 +19,8 @@ llama-index-embeddings-azure-openai = { git = "https://github.com/run-llama/llam
 llama-index-embeddings-gemini = { git = "https://github.com/run-llama/llama_index.git", branch = "main", subdirectory = "llama-index-integrations/embeddings/llama-index-embeddings-gemini" }
 llama-index-embeddings-huggingface = { git = "https://github.com/run-llama/llama_index.git", branch = "main", subdirectory = "llama-index-integrations/embeddings/llama-index-embeddings-huggingface" }
 llama-index-multi-modal-llms-gemini = { git = "https://github.com/run-llama/llama_index.git", branch = "main", subdirectory = "llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini" }
-
 llama-parse = { git = "https://github.com/run-llama/llama_parse.git", branch = "main" }
 
-langchain = { version = "0.1.2" }
-langchain-core = "0.1.15"
-langchain-community = "0.0.15"
-langchain-openai = { version = "0.0.3" }
-langchain-google-genai = { version = "0.0.6" }
-langchain-google-vertexai = { version = "0.0.3" }
-langchain-nvidia-ai-endpoints = { version = "0.0.1" }
-astrapy = "~0.7.0"
-# we need this specific feature from cassio: https://github.com/CassioML/cassio/pull/128
+# update these to specific versions
 cassio = "~0.1.4"
-unstructured = "^0.10"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+google-cloud-aiplatform = "^1.36.4"

--- a/ragstack-e2e-tests/pyproject.ragstack-ai.toml
+++ b/ragstack-e2e-tests/pyproject.ragstack-ai.toml
@@ -1,42 +1,20 @@
-[tool.poetry]
-name = "ragstack-e2e-tests"
-version = "0.1.0"
-description = "RAGStack tests"
-license = ""
-authors = ["DataStax"]
-
-[tool.poetry.dependencies]
-python = ">=3.9,<3.12,!=3.9.7"
+# changes required for ragstack-ai latest tests
 
 [tool.poetry.group.test.dependencies]
-pytest = "*"
-black = "*"
-ruff = "*"
-google-cloud-aiplatform = "^1.36.4"
-langchain-google-genai = "^0.0.4"
-langchain-nvidia-ai-endpoints = "^0.0.1"
-boto3 = "^1.29.6"
-huggingface-hub = "^0.20.3"
-azure-storage-blob = "^12.19.0"
-pillow = "^10.2.0"
-testcontainers = "^3.7.1"
-python-dotenv = "^1.0.1"
-trulens-eval = "^0.21.0"
+#remove from the ragstack-e2e-tests pyproject
+ragstack-ai = ""
 
-# From LangChain optional deps, needed by WebBaseLoader
-beautifulsoup4 = "^4"
-# we need this specific feature from cassio: https://github.com/CassioML/cassio/pull/128
+# remove the following from the root ragstack-ai pyproject
+astrapy = ""
+unstructured = ""
+llama-index = ""
+llama-parse = ""
+langchain = ""
+langchain-core = ""
+langchain-community = ""
+langchain-openai = ""
+langchain-google-vertexai = ""
+
+# update these to specific versions
 cassio = "~0.1.4"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
-
-[tool.ruff]
-line-length = 250
-
-[tool.pytest.ini_options]
-log_cli = true
-log_cli_level = "INFO"
-log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
-log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+google-cloud-aiplatform = "^1.36.4"

--- a/ragstack-e2e-tests/tox.ini
+++ b/ragstack-e2e-tests/tox.ini
@@ -33,27 +33,24 @@ commands =
     poetry install --no-root
     poetry run pytest --disable-warnings --junit-xml=results.xml {posargs:e2e_tests}
 
-[testenv:langchain]
-allowlist_externals = cp
+[testenv:langchain-latest]
 commands =
-    cp pyproject.langchain.toml pyproject.toml
+    python ../scripts/generate-pyproject.py ../pyproject.toml pyproject.toml pyproject.langchain.toml pyproject.toml
     poetry lock
     poetry install --no-root
     poetry run pytest --disable-warnings --junit-xml=results.xml {posargs:e2e_tests}
 
-[testenv:llamaindex]
-allowlist_externals = cp
+[testenv:llamaindex-latest]
 commands =
-    cp pyproject.llamaindex.toml pyproject.toml
+    python ../scripts/generate-pyproject.py ../pyproject.toml pyproject.toml pyproject.llamaindex.toml pyproject.toml
     poetry lock
     poetry install --no-root
     poetry run pytest --disable-warnings --junit-xml=results.xml {posargs:e2e_tests}
 
 [testenv:ragstack-ai-latest]
 envdir = {toxworkdir}/.ragstack-ai-latest
-allowlist_externals = cp
 commands =
-    cp pyproject.ragstack-ai.toml pyproject.toml
+    python ../scripts/generate-pyproject.py ../pyproject.toml pyproject.toml pyproject.ragstack-ai.toml pyproject.toml
     poetry add ragstack-ai@latest
     poetry lock
     poetry install --no-root

--- a/scripts/generate-pyproject.py
+++ b/scripts/generate-pyproject.py
@@ -1,0 +1,63 @@
+import toml
+import sys
+
+from toml.decoder import InlineTableDict
+
+def deep_update(base, updater):
+    for key, value in updater.items():
+        if isinstance(value, InlineTableDict):
+            base[key] = value
+        elif isinstance(value, dict):
+            base[key] = deep_update(base.get(key, {}), value)
+        elif value == "":
+            del base[key]
+        else:
+            base[key] = value
+    return base
+
+def generate_pyproject(rag_stack_path, e2e_tests_path, update_file_path, output_file_path):
+    with open(rag_stack_path, 'r') as rag_stack, open(e2e_tests_path, 'r') as e2e_tests, open(update_file_path, 'r') as update_file:
+        rag_stack_data = toml.load(rag_stack)
+        e2e_tests_data = toml.load(e2e_tests)
+        update_data = toml.load(update_file)
+
+        # grab all the RAGstack module dependencies from the root project.toml
+        root_dependencies = rag_stack_data["tool"]["poetry"]["dependencies"]
+
+        # remove the root `python` dependency
+        if "python" in root_dependencies:
+            del root_dependencies["python"]
+
+        # remove `optional` flags if they exist
+        for root_dependency in root_dependencies:
+            if "optional" in root_dependencies[root_dependency]:
+                del root_dependencies[root_dependency]["optional"]
+
+        # get all the test dependencies from the ragstack-e2e-tests module
+        test_dependencies = e2e_tests_data["tool"]["poetry"]["group"]["test"]["dependencies"]
+
+        # merge the RAGstack dependencies into the test dependencies
+        merged_dependencies = deep_update(test_dependencies, root_dependencies)
+
+        # save the merged test dependencies back into the test pyproject data
+        e2e_tests_data["tool"]["poetry"]["group"]["test"]["dependencies"] = merged_dependencies
+
+        # merge the update data into the test pyproject data
+        merged_data = deep_update(e2e_tests_data, update_data)
+
+        # output the combined pyproject file
+        with open(output_file_path, 'w') as output_file:
+            toml.dump(merged_data, output_file, encoder=toml.TomlPreserveInlineDictEncoder())
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        print("Usage: python merge_toml.py pyproject.toml ragstack-e2e-tests/pyproject.toml ragstack-e2e-tests/pyproject.update.toml pyproject.output.toml")
+        sys.exit(1)
+
+    rag_stack_file_path = sys.argv[1]
+    e2e_tests_file_path = sys.argv[2]
+    update_file_path = sys.argv[3]
+    output_file_path = sys.argv[4]
+
+    generate_pyproject(rag_stack_file_path, e2e_tests_file_path, update_file_path, output_file_path)
+    print(f"Generated pyproject: `{output_file_path}` from `{rag_stack_file_path} (tool.poetry.dependencies)` plus `{e2e_tests_file_path}` and `{update_file_path}`")


### PR DESCRIPTION
We have been bad at updating dependencies in our **"latest"** test cases to match the versions used in the core `ragstack-ai` package. 

For example, in our llama-index-latest test environment, we are using:
```
langchain = { version = "0.1.2" }
langchain-core = "0.1.15"
langchain-community = "0.0.15"
```

But ragstack-ai currently uses these versions of those packages:

```
langchain = { version = "0.1.4" }
langchain-core = "0.1.16"
langchain-community = "0.0.16"
```

Therefore I made a script to generate the `pyproject.toml` files from the existing core package, the test package, and a set of differences for the specific "latest" test environment.

A side benefit is that it is much easier to see the differences in the latest `pyproject.toml` files now. 

Note: If this change isn't liked by the team, I won't mind if we close the PR.



 