### PR TITLE
change py range to <3.12

### DIFF
--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -46,6 +46,11 @@ jobs:
       - name: "Setup: Python 3.11"
         uses: ./.github/actions/setup-python
 
+      - name: "Build"
+        run: |
+          poetry install --no-root
+          poetry build
+
       - name: Run ragstack-ai unit tests
         run: |
           tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.datastax.com/en/ragstack"
 packages = [{ include = "ragstack" }]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+python = ">=3.9,<3.12"
 astrapy = "~0.7.0"
 cassio = "~0.1.3"
 unstructured = { version = "0.12.5" }


### PR DESCRIPTION
```
The current project's supported Python range (>=3.9,<4.0) is not compatible with some of the required packages Python requirement:
[249](https://github.com/datastax/ragstack-ai/actions/runs/8081337583/job/22079661904#step:4:252)
  - unstructured requires Python >=3.9.0,<3.12, so it will not be satisfied for Python >=3.12,<4.0
```