### PR TITLE
ci: run unit tests even for docs only change

### DIFF
--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -8,11 +8,6 @@ on:
     - cron: "0 2/4 * * *"
     - cron: "0 3/4 * * *"
   pull_request:
-    paths-ignore:
-      - "scripts/**"
-      - "docs/**"
-      - "README.adoc"
-      - "PACKAGE_README.md"
     branches:
       - main
 

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -1,11 +1,6 @@
 name: CI - Unit tests
 on:
   pull_request:
-    paths-ignore:
-      - "scripts/**"
-      - "docs/**"
-      - "README.adoc"
-      - "PACKAGE_README.md"
     branches:
       - main
 


### PR DESCRIPTION
docs-only changes make the CI to be skipped (and it's fine) but the GH checks required to a PR to be merged aren't completed in this way. 
For usability, it's way better to run unit tests and have the PR green. 

there are alternatives to this approach, like checking a single job result that is computed dinamically, but it's not worth it. let's run the unit tests always 