### PR TITLE
[tests] temporarily disable GPT4 tests

### DIFF
--- a/ragstack-e2e-tests/e2e_tests/langchain/test_compatibility_rag.py
+++ b/ragstack-e2e-tests/e2e_tests/langchain/test_compatibility_rag.py
@@ -243,8 +243,8 @@ def nvidia_aifoundation_mixtral8x7b_llm():
     "embedding,llm",
     [
         ("openai_ada002_embedding", "openai_gpt35turbo_llm"),
-        ("openai_3small_embedding", "openai_gpt4_llm"),
-        ("openai_3large_embedding", "openai_gpt4_llm_streaming"),
+        # ("openai_3small_embedding", "openai_gpt4_llm"),
+        # ("openai_3large_embedding", "openai_gpt4_llm_streaming"),
         ("azure_openai_ada002_embedding", "azure_openai_gpt35turbo_llm"),
         ("vertex_gecko_embedding", "vertex_bison_llm"),
         ("bedrock_titan_embedding", "bedrock_anthropic_claudev2_llm"),


### PR DESCRIPTION
We've noticed high levels of gpt4 api usage, resulting in high costs. Temporarily commenting these out until we can reduce the frequency of different test suites. 