### PR TITLE
replaced "title" with "id" for ColBERT document identifier

### DIFF
--- a/ragstack/colbert/__init__.py
+++ b/ragstack/colbert/__init__.py
@@ -1,19 +1,19 @@
 from .colbert_embedding import ColbertTokenEmbeddings
-from .cassandra_store import CassandraColBERTVectorStore
+from .cassandra_store import CassandraColbertVectorStore
 from .cassandra_retriever import ColbertCassandraRetriever, max_similarity_torch
 from .token_embedding import PerTokenEmbeddings, PassageEmbeddings, TokenEmbeddings
-from .vector_store import ColBERTVectorStore
+from .vector_store import ColbertVectorStore
 from .constant import DEFAULT_COLBERT_MODEL, DEFAULT_COLBERT_DIM
 
 __all__ = (
     ColbertTokenEmbeddings,
-    CassandraColBERTVectorStore,
+    CassandraColbertVectorStore,
     ColbertCassandraRetriever,
     max_similarity_torch,
     PerTokenEmbeddings,
     PassageEmbeddings,
     TokenEmbeddings,
-    ColBERTVectorStore,
+    ColbertVectorStore,
     DEFAULT_COLBERT_MODEL,
     DEFAULT_COLBERT_DIM,
 )

--- a/ragstack/colbert/cassandra_retriever.py
+++ b/ragstack/colbert/cassandra_retriever.py
@@ -159,7 +159,7 @@ class ColbertCassandraRetriever(ColbertVectorStoreRetriever):
             rs = doc_futures[(doc_id, part_id)].result()
             score = scores[(doc_id, part_id)]
             answers.append(
-                Chunk(doc_id=doc_id, score=score.item(), rank=rank, text=rs.one().body)
+                Chunk(doc_id=doc_id, part_id=part_id, score=score.item(), rank=rank, text=rs.one().body)
             )
             rank = rank + 1
         # clean up on tensor memory on GPU

--- a/ragstack/colbert/cassandra_store.py
+++ b/ragstack/colbert/cassandra_store.py
@@ -22,8 +22,8 @@ class CassandraColbertVectorStore(ColbertVectorStore):
         # prepare statements
         self.insert_chunk_stmt = self.session.prepare(
             f"""
-        INSERT INTO {self.full_table_name} (doc_id, part_id, body, embedding_id)
-        VALUES (?, ?, ?, -1)
+        INSERT INTO {self.full_table_name} (doc_id, part_id, embedding_id, body)
+        VALUES (?, ?, -1, ?)
         """
         )
 
@@ -38,7 +38,6 @@ class CassandraColbertVectorStore(ColbertVectorStore):
             f"""
         SELECT doc_id, part_id
         FROM {self.full_table_name}
-        WHERE embedding_id != -1
         ORDER BY bert_embedding ANN OF ?
         LIMIT ?
         """

--- a/ragstack/colbert/langchain/__init__.py
+++ b/ragstack/colbert/langchain/__init__.py
@@ -1,3 +1,3 @@
-from .retriever import ColBERTVectorStoreLangChainRetriever
+from .retriever import ColbertVectorStoreLangChainRetriever
 
-__all__ = (ColBERTVectorStoreLangChainRetriever,)
+__all__ = (ColbertVectorStoreLangChainRetriever,)

--- a/ragstack/colbert/langchain/retriever.py
+++ b/ragstack/colbert/langchain/retriever.py
@@ -44,6 +44,6 @@ class ColBERTVectorStoreLangChainRetriever(BaseRetriever):
         """Get documents relevant to a query."""
         answers = self.retriever.retrieve(query, self.k)
         return [
-            Document(metadata={"title": d.title, "rank": d.rank}, page_content=d.body)
+            Document(metadata={"id": d.id, "rank": d.rank}, page_content=d.body)
             for d in answers
         ]

--- a/ragstack/colbert/langchain/retriever.py
+++ b/ragstack/colbert/langchain/retriever.py
@@ -4,10 +4,10 @@ from typing import List
 from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
-from ..vector_store import ColBERTVectorStoreRetriever
+from ..vector_store import ColbertVectorStoreRetriever
 
 
-class ColBERTVectorStoreLangChainRetriever(BaseRetriever):
+class ColbertVectorStoreLangChainRetriever(BaseRetriever):
     """Chain for langchain retrieve using ColBERT vector store.
 
     Example:
@@ -17,11 +17,11 @@ class ColBERTVectorStoreLangChainRetriever(BaseRetriever):
         from langchain_openai import AzureChatOpenAI
 
         llm = AzureChatOpenAI()
-        retriever = ColBERTVectorStoreLangChainRetriever(colbertCassandraRetriever, k=2)
+        retriever = ColbertVectorStoreLangChainRetriever(colbertCassandraRetriever, k=5)
         qa = RetrievalQA.from_chain_type(llm=llm, chain_type="stuff", retriever=retriever)
         qa.run("what happened on June 4th?")
     """
-    retriever: ColBERTVectorStoreRetriever = Field(default=None)
+    retriever: ColbertVectorStoreRetriever = Field(default=None)
     kwargs: dict = {}
     k: int = 10
 
@@ -30,7 +30,7 @@ class ColBERTVectorStoreLangChainRetriever(BaseRetriever):
 
         arbitrary_types_allowed = True
 
-    def __init__(self, retriever: ColBERTVectorStoreRetriever, k: int = 10, **kwargs):
+    def __init__(self, retriever: ColbertVectorStoreRetriever, k: int = 10, **kwargs):
         super().__init__(retriever=retriever, k=k, **kwargs)
         self.retriever = retriever
         self.k = k
@@ -42,8 +42,8 @@ class ColBERTVectorStoreLangChainRetriever(BaseRetriever):
         run_manager: CallbackManagerForRetrieverRun,  # noqa
     ) -> List[Document]:
         """Get documents relevant to a query."""
-        answers = self.retriever.retrieve(query, self.k)
+        chunks = self.retriever.retrieve(query, self.k)
         return [
-            Document(metadata={"id": d.id, "rank": d.rank}, page_content=d.body)
-            for d in answers
+            Document(metadata={"id": c.doc_id, "rank": c.rank}, page_content=c.text)
+            for c in chunks
         ]

--- a/ragstack/colbert/token_embedding.py
+++ b/ragstack/colbert/token_embedding.py
@@ -14,13 +14,11 @@ class PerTokenEmbeddings:
         self,
         id: int,
         part: int,
-        parent_id: uuid.UUID = None,
-        title: str = "",
+        parent_id: uuid.UUID = None
     ):
         self.id = id
         self.parent_id = parent_id
         self.__embeddings = []
-        self.title = title
         self.part = part
 
     def add_embeddings(self, embeddings: List[float]):
@@ -42,13 +40,11 @@ class PerTokenEmbeddings:
 class PassageEmbeddings:
     __token_embeddings: List[PerTokenEmbeddings]
     __text: str
-    __title: str
     __id: uuid.UUID
 
     def __init__(
         self,
         text: str,
-        title: str = "",
         part: int = 0,
         id: uuid.UUID = None,
         model: str = DEFAULT_COLBERT_MODEL,
@@ -62,7 +58,6 @@ class PassageEmbeddings:
             self.__id = id
         self.__model = model
         self.__dim = dim
-        self.__title = title
         self.__part = part
 
     def model(self):
@@ -73,9 +68,6 @@ class PassageEmbeddings:
 
     def token_size(self):
         return len(self.token_ids)
-
-    def title(self):
-        return self.__title
 
     def __len__(self):
         return len(self.embeddings)

--- a/ragstack/colbert/token_embedding.py
+++ b/ragstack/colbert/token_embedding.py
@@ -3,23 +3,26 @@
 
 from abc import ABC, abstractmethod
 from typing import List
-from .constant import DEFAULT_COLBERT_DIM, DEFAULT_COLBERT_MODEL
-import uuid
-
 
 class PerTokenEmbeddings:
     __embeddings: List[float]
+    __embedding_id: int
+    __part_id: int
 
     def __init__(
         self,
-        id: int,
-        part: int,
-        parent_id: uuid.UUID = None
+        embedding_id: int,
+        part_id: int
     ):
-        self.id = id
-        self.parent_id = parent_id
         self.__embeddings = []
-        self.part = part
+        self.__embedding_id = embedding_id
+        self.__part_id = part_id
+
+    def embedding_id(self):
+        return self.__embedding_id
+
+    def part_id(self):
+        return self.__part_id
 
     def add_embeddings(self, embeddings: List[float]):
         self.__embeddings = embeddings
@@ -27,79 +30,49 @@ class PerTokenEmbeddings:
     def get_embeddings(self) -> List[float]:
         return self.__embeddings
 
-    def id(self):
-        return self.id
-
-    def parent_id(self):
-        return self.parent_id
-
-    def part(self):
-        return self.part
-
 
 class PassageEmbeddings:
     __token_embeddings: List[PerTokenEmbeddings]
     __text: str
-    __id: uuid.UUID
+    __doc_id: str
+    __part_id: int
 
     def __init__(
         self,
         text: str,
-        part: int = 0,
-        id: uuid.UUID = None,
-        model: str = DEFAULT_COLBERT_MODEL,
-        dim: int = DEFAULT_COLBERT_DIM,
+        doc_id: str = None,
+        part_id: int = 0,
     ):
         self.__text = text
         self.__token_embeddings = []
-        if id is None:
-            self.__id = uuid.uuid4()
-        else:
-            self.__id = id
-        self.__model = model
-        self.__dim = dim
-        self.__part = part
-
-    def model(self):
-        return self.__model
-
-    def dim(self):
-        return self.__dim
-
-    def token_size(self):
-        return len(self.token_ids)
+        self.__doc_id = doc_id
+        self.__part_id = part_id
 
     def __len__(self):
         return len(self.embeddings)
 
-    def id(self):
-        return self.__id
+    def doc_id(self):
+        return self.__doc_id
 
-    def part(self):
-        return self.__part
+    def part_id(self):
+        return self.__part_id
+
+    def text(self):
+        return self.__text
 
     def add_token_embeddings(self, token_embeddings: PerTokenEmbeddings):
         self.__token_embeddings.append(token_embeddings)
 
-    def get_token_embeddings(self, token_id: int) -> PerTokenEmbeddings:
-        for token in self.__token_embeddings:
-            if token.token_id == token_id:
-                return token
-        return None
-
     def get_all_token_embeddings(self) -> List[PerTokenEmbeddings]:
         return self.__token_embeddings
 
-    def get_text(self):
-        return self.__text
+
 
 
 """
 This is the base class for token based embedding
 ColBERT token embeddings is an example of a class that inherits from this class
 """
-
-
 class TokenEmbeddings(ABC):
     """Interface for token embedding models."""
 

--- a/ragstack/colbert/vector_store.py
+++ b/ragstack/colbert/vector_store.py
@@ -8,7 +8,7 @@ from numbers import Number
 from typing import List, Optional
 
 
-class ColBERTVectorStore(ABC):
+class ColbertVectorStore(ABC):
     """Interface for a vector store."""
 
     @abstractmethod
@@ -28,14 +28,15 @@ class ColBERTVectorStore(ABC):
 
 
 @dataclasses.dataclass
-class Document:
-    id: str
-    body: str
+class Chunk:
+    doc_id: str
+    part_id: int
+    text: str
     rank: int
     score: Number
 
 
-class ColBERTVectorStoreRetriever(ABC):
+class ColbertVectorStoreRetriever(ABC):
     @abstractmethod
     def close(self):
         """Close the store."""
@@ -44,6 +45,6 @@ class ColBERTVectorStoreRetriever(ABC):
     @abstractmethod
     def retrieve(
         self, query: str, k: Optional[int], query_maxlen: Optional[int], **kwargs
-    ) -> List[Document]:
-        """Retrieve documents from the store"""
+    ) -> List[Chunk]:
+        """Retrieve chunks from the store"""
         pass

--- a/ragstack/colbert/vector_store.py
+++ b/ragstack/colbert/vector_store.py
@@ -22,14 +22,14 @@ class ColBERTVectorStore(ABC):
         pass
 
     @abstractmethod
-    def delete_documents(self, titles: List[str]):
+    def delete_documents(self, ids: List[str]):
         """Delete a document from the store."""
         pass
 
 
 @dataclasses.dataclass
 class Document:
-    title: str
+    id: str
     body: str
     rank: int
     score: Number

--- a/tests/integration_tests/test_colbert_embedding_retrieval.py
+++ b/tests/integration_tests/test_colbert_embedding_retrieval.py
@@ -3,8 +3,8 @@ import logging
 import pytest
 from ragstack.colbert import ColbertTokenEmbeddings
 from ragstack.colbert import ColbertCassandraRetriever
-from ragstack.colbert import CassandraColBERTVectorStore
-from ragstack.colbert.langchain import ColBERTVectorStoreLangChainRetriever
+from ragstack.colbert import CassandraColbertVectorStore
+from ragstack.colbert.langchain import ColbertVectorStoreLangChainRetriever
 
 from tests.integration_tests.conftest import (
     get_local_cassandra_test_store,
@@ -65,7 +65,7 @@ def test_embedding_cassandra_retriever(request, vector_store: str):
     for i, chunk in enumerate(chunks[:3]):  # Displaying the first 3 chunks for brevity
         logging.info(f"Chunk {i + 1}:\n{chunk}\n{'-' * 50}\n")
 
-    id = "Marine Animals habitat"
+    doc_id = "Marine Animals habitat"
 
     # colbert stuff starts
     colbert = ColbertTokenEmbeddings(
@@ -74,11 +74,11 @@ def test_embedding_cassandra_retriever(request, vector_store: str):
         kmeans_niters=4,
     )
 
-    passage_embeddings = colbert.embed_documents(texts=chunks, id=id)
+    passage_embeddings = colbert.embed_documents(texts=chunks, doc_id=doc_id)
 
     logging.info(f"passage embeddings size {len(passage_embeddings)}")
 
-    store = CassandraColBERTVectorStore(
+    store = CassandraColbertVectorStore(
         keyspace=KEYSPACE,
         table_name="colbert_embeddings",
         session=vector_store.create_cassandra_session(),
@@ -93,6 +93,6 @@ def test_embedding_cassandra_retriever(request, vector_store: str):
         logging.info(f"got {doc}")
     assert len(docs) == 5
 
-    lc_retriever = ColBERTVectorStoreLangChainRetriever(retriever, k=2)
+    lc_retriever = ColbertVectorStoreLangChainRetriever(retriever, k=2)
     docs = lc_retriever.get_relevant_documents("what kind fish lives shallow coral reefs atlantic, india ocean, red sea, gulf of mexico, pacific, and arctic ocean")
     assert len(docs) == 2

--- a/tests/integration_tests/test_colbert_embedding_retrieval.py
+++ b/tests/integration_tests/test_colbert_embedding_retrieval.py
@@ -65,7 +65,7 @@ def test_embedding_cassandra_retriever(request, vector_store: str):
     for i, chunk in enumerate(chunks[:3]):  # Displaying the first 3 chunks for brevity
         logging.info(f"Chunk {i + 1}:\n{chunk}\n{'-' * 50}\n")
 
-    title = "Marine Animals habitat"
+    id = "Marine Animals habitat"
 
     # colbert stuff starts
     colbert = ColbertTokenEmbeddings(
@@ -74,7 +74,7 @@ def test_embedding_cassandra_retriever(request, vector_store: str):
         kmeans_niters=4,
     )
 
-    passage_embeddings = colbert.embed_documents(texts=chunks, title=title)
+    passage_embeddings = colbert.embed_documents(texts=chunks, id=id)
 
     logging.info(f"passage embeddings size {len(passage_embeddings)}")
 

--- a/tests/unit_tests/test_colbert_embeddings.py
+++ b/tests/unit_tests/test_colbert_embeddings.py
@@ -14,17 +14,17 @@ def test_colbert_token_embeddings():
     assert passagesEmbeddings[0].get_text() == "test1"
     assert passagesEmbeddings[1].get_text() == "test2"
 
-    # generate uuid based title
-    assert passagesEmbeddings[0].title() != ""
-    assert passagesEmbeddings[1].title() != ""
+    # generate uuid based id
+    assert passagesEmbeddings[0].id() != ""
+    assert passagesEmbeddings[1].id() != ""
 
     passageEmbeddings = colbert.embed_documents(
-        texts=["test1", "test2"], title="test-title"
+        texts=["test1", "test2"], id="test-id"
     )
 
     assert passageEmbeddings[0].get_text() == "test1"
-    assert passageEmbeddings[0].title() == "test-title"
-    assert passageEmbeddings[1].title() == "test-title"
+    assert passageEmbeddings[0].id() == "test-id"
+    assert passageEmbeddings[1].id() == "test-id"
 
     token_embeddings = passagesEmbeddings[0].get_all_token_embeddings()
     assert len(token_embeddings[0].get_embeddings()) == DEFAULT_COLBERT_DIM

--- a/tests/unit_tests/test_colbert_embeddings.py
+++ b/tests/unit_tests/test_colbert_embeddings.py
@@ -11,20 +11,20 @@ def test_colbert_token_embeddings():
 
     assert len(passagesEmbeddings) == 2
 
-    assert passagesEmbeddings[0].get_text() == "test1"
-    assert passagesEmbeddings[1].get_text() == "test2"
+    assert passagesEmbeddings[0].text() == "test1"
+    assert passagesEmbeddings[1].text() == "test2"
 
     # generate uuid based id
-    assert passagesEmbeddings[0].id() != ""
-    assert passagesEmbeddings[1].id() != ""
+    assert passagesEmbeddings[0].doc_id() != ""
+    assert passagesEmbeddings[1].doc_id() != ""
 
     passageEmbeddings = colbert.embed_documents(
-        texts=["test1", "test2"], id="test-id"
+        texts=["test1", "test2"], doc_id="test-id"
     )
 
-    assert passageEmbeddings[0].get_text() == "test1"
-    assert passageEmbeddings[0].id() == "test-id"
-    assert passageEmbeddings[1].id() == "test-id"
+    assert passageEmbeddings[0].text() == "test1"
+    assert passageEmbeddings[0].doc_id() == "test-id"
+    assert passageEmbeddings[1].doc_id() == "test-id"
 
     token_embeddings = passagesEmbeddings[0].get_all_token_embeddings()
     assert len(token_embeddings[0].get_embeddings()) == DEFAULT_COLBERT_DIM
@@ -44,8 +44,8 @@ def test_colbert_token_embeddings_with_params():
 
     assert len(passage_embeddings) == 3
 
-    assert passage_embeddings[0].get_text() == "test1"
-    assert passage_embeddings[1].get_text() == "test2"
+    assert passage_embeddings[0].text() == "test1"
+    assert passage_embeddings[1].text() == "test2"
 
     token_embeddings = passage_embeddings[0].get_all_token_embeddings()
     assert len(token_embeddings) > 1


### PR DESCRIPTION
ColBERT should not require a `title` for each document. It should be an optional `id`, that is generated if not passed.

If a developer wants to save the `filename` or other `title` for a document, they should do it in the metadata.

This PR is in place of https://github.com/datastax/ragstack-ai/pull/338

Also made a bunch of other name changes.