### PR TITLE
made various changes to cleanup retrieval

### DIFF
--- a/ragstack/colbert/cassandra_retriever.py
+++ b/ragstack/colbert/cassandra_retriever.py
@@ -209,7 +209,7 @@ class ColbertCassandraRetriever(ColbertVectorStoreRetriever):
         ) -> Tuple[Tuple[str, int], List[Tensor]] | None:
             try:
                 async_future = self.vector_store.session.execute_async(
-                    self.vector_store.query_chunk_stmt,
+                    self.vector_store.query_colbert_chunks_stmt,
                     [doc_id, chunk_id],
                     timeout=query_timeout,
                 )

--- a/ragstack/colbert/cassandra_retriever.py
+++ b/ragstack/colbert/cassandra_retriever.py
@@ -128,7 +128,7 @@ class ColbertCassandraRetriever(ColbertVectorStoreRetriever):
         self,
         vector_store: CassandraColbertVectorStore,
         colbert_embeddings: ColbertTokenEmbeddings,
-        max_casandra_workers: Optional[int] = 10,
+        max_workers: Optional[int] = 20,
     ):
         """
         Initializes the retriever with a specific vector store and Colbert embeddings model.
@@ -137,15 +137,15 @@ class ColbertCassandraRetriever(ColbertVectorStoreRetriever):
             vector_store (CassandraColbertVectorStore): The vector store to be used for retrieving embeddings.
             colbert_embeddings (ColbertTokenEmbeddings): The ColBERT embeddings model to be used for encoding
                                                          queries.
-            max_casandra_workers: The maximum number of concurrent requests to make to Cassandra on a
-                                  per-retrieval basis.
+            max_workers: The maximum number of concurrent requests to make to Cassandra on a per-retrieval basis.
         """
 
         self.vector_store = vector_store
         self.colbert_embeddings = colbert_embeddings
         self.is_cuda = torch.cuda.is_available()
         self.is_fp16 = all_gpus_support_fp16(self.is_cuda)
-        self.executor = ThreadPoolExecutor(max_workers=max_casandra_workers)
+        self.max_workers = max_workers
+        self.executor = ThreadPoolExecutor(max_workers=max_workers)
 
     def close(self) -> None:
         """

--- a/ragstack/colbert/cassandra_retriever.py
+++ b/ragstack/colbert/cassandra_retriever.py
@@ -206,7 +206,7 @@ class ColbertCassandraRetriever(ColbertVectorStoreRetriever):
 
         def fetch_chunk_data(
             doc_id: str, chunk_id: int
-        ) -> Tuple[Tuple[str, int], List[Tensor]] | None:
+        ) -> Tuple[Tuple[str, int], List[Tensor]]:
             try:
                 async_future = self.vector_store.session.execute_async(
                     self.vector_store.query_colbert_chunks_stmt,

--- a/ragstack/colbert/cassandra_retriever.py
+++ b/ragstack/colbert/cassandra_retriever.py
@@ -173,7 +173,7 @@ class ColbertCassandraRetriever(ColbertVectorStoreRetriever):
                 for embedding in embeddings:
                     local_chunks.add((embedding.doc_id, embedding.chunk_id))
             except ReadTimeout:
-                logging.warn(f"Query timeout with params: {query_vector}, {top_k}")
+                logging.error(f"Query timeout with params: {query_vector}, {top_k}")
                 # Handle the timeout or other potential exceptions as needed
             except Exception as e:
                 logging.error(
@@ -218,7 +218,7 @@ class ColbertCassandraRetriever(ColbertVectorStoreRetriever):
                     torch.tensor(row.bert_embedding) for row in rows
                 ]
             except ReadTimeout:
-                logging.warn(f"Query timeout for doc_id {doc_id}, chunk_id {chunk_id}")
+                logging.error(f"Query timeout for doc_id {doc_id}, chunk_id {chunk_id}")
             except Exception as e:
                 logging.error(
                     f"Error fetching chunk data for doc_id {doc_id}, chunk_id {chunk_id}: {e}"

--- a/ragstack/colbert/cassandra_retriever.py
+++ b/ragstack/colbert/cassandra_retriever.py
@@ -108,7 +108,7 @@ class ColbertCassandraRetriever(ColbertVectorStoreRetriever):
         is_cuda (bool): A flag indicating whether to use CUDA (GPU) for computation.
         is_fp16 (bool): A flag indicating whether to half-precision floating point operations on CUDA (GPU).
                         Has no effect on CPU computation.
-        max_casandra_workers: The maximum number of concurrent requests to make to Cassandra on a per-retrieval basis.
+        max_workers: The maximum number of concurrent requests to make to the vector store on a per-retrieval basis.
 
     Note:
         The class is designed to work with a GPU for optimal performance but will automatically fall back to CPU
@@ -117,7 +117,7 @@ class ColbertCassandraRetriever(ColbertVectorStoreRetriever):
 
     vector_store: CassandraColbertVectorStore
     colbert_embeddings: ColbertTokenEmbeddings
-    max_casandra_workers: int
+    max_workers: int
     is_cuda: bool = False
     is_fp16: bool = False
 

--- a/ragstack/colbert/chunk_encoder.py
+++ b/ragstack/colbert/chunk_encoder.py
@@ -60,7 +60,7 @@ class ChunkEncoder:
 
     def encode_chunks(
         self, texts: List[str], batch_size: int = 64
-    ) -> tuple[None, None] | tuple[Tensor, List[int]]:
+    ) -> tuple[Tensor, List[int]]:
         """
         Encodes a list of chunks into embeddings, processing in batches to efficiently manage memory.
 

--- a/ragstack/colbert/colbert_embedding.py
+++ b/ragstack/colbert/colbert_embedding.py
@@ -116,7 +116,7 @@ class ColbertTokenEmbeddings(TokenEmbeddings):
             and not dist.is_initialized()
             and distributed_communication
         ):
-            logging.warn(f"distribution initialization must complete on {nranks} gpus")
+            logging.info(f"distribution initialization must complete on {nranks} gpus")
             Distributed(self.__nranks)
             logging.info("distribution initialization completed")
 

--- a/ragstack/colbert/runner.py
+++ b/ragstack/colbert/runner.py
@@ -156,7 +156,7 @@ class Runner:
         for p, info in zip(processes, proc_info):
             p.join(timeout=timeout)
             if p.is_alive():
-                logging.warning(
+                logging.error(
                     f"embedding process timed out process PID: {info[0]}, Name: {info[1]}"
                 )
                 timed_out_processes.append(p)

--- a/tests/integration_tests/test_colbert_embedding_retrieval.py
+++ b/tests/integration_tests/test_colbert_embedding_retrieval.py
@@ -28,6 +28,8 @@ def astra_db():
 
 @pytest.mark.parametrize("vector_store", ["cassandra"])
 def test_embedding_cassandra_retriever(request, vector_store: str):
+    logging.getLogger('cassandra').setLevel(logging.ERROR)
+    
     vector_store = request.getfixturevalue(vector_store)
     narrative = """
     Marine animals inhabit some of the most diverse environments on our planet. From the shallow coral reefs teeming with colorful fish to the dark depths of the ocean where mysterious creatures lurk, the marine world is full of wonder and mystery.

--- a/tests/integration_tests/test_colbert_embedding_retrieval.py
+++ b/tests/integration_tests/test_colbert_embedding_retrieval.py
@@ -28,8 +28,6 @@ def astra_db():
 
 @pytest.mark.parametrize("vector_store", ["cassandra"])
 def test_embedding_cassandra_retriever(request, vector_store: str):
-    logging.getLogger('cassandra').setLevel(logging.ERROR)
-    
     vector_store = request.getfixturevalue(vector_store)
     narrative = """
     Marine animals inhabit some of the most diverse environments on our planet. From the shallow coral reefs teeming with colorful fish to the dark depths of the ocean where mysterious creatures lurk, the marine world is full of wonder and mystery.


### PR DESCRIPTION
made a bunch of changes that generally make sure our ColBERT retrieval code interacts nicely with Cassandra (doesn't overload the database when making queries). 

There is little change in retrieval latency with these changes running on CPU.

* wrapped async calls to cassandra inside a `ThreadPoolExecutor`.  
  * We should experiment to see what value of `max_casandra_workers` works the best.

* automatically dropping down to half-precision when calculating chunk scores, if running on GPU and the GPU supports it.  
  * We should test to see if `is_fp16` flag is getting set to `True` on boxes with CUDA support. 
  * I "think" that half-precision won't hurt our results, and chatGPT claims this can "significantly speed up our calculations & reduce memory usage on the GPU".
