### PR TITLE
Antora JS Scaffolding

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -4,6 +4,12 @@
 * xref:ROOT:dev-environment.adoc[]
 * xref:ROOT:migration.adoc[]
 
+.Get Started (JS/TS)
+* xref:ragstack-js:index.adoc[]
+* xref:ragstack-js:quickstart-js.adoc[]
+* xref:ragstack-js:dev-environment-js.adoc[]
+* xref:ragstack-js:migration-js.adoc[]
+
 .RAG Default architecture
 * xref:default-architecture:index.adoc[]
 * xref:default-architecture:loading.adoc[]
@@ -40,6 +46,7 @@
 
 .Release notes
 * xref:ROOT:changelog.adoc[]
+* xref:ragstack-js:changelog-js.adoc[]
 
 .API Reference
 * https://datastax.github.io/ragstack-ai/api_reference/0.10.0/langchain[0.10.0]

--- a/docs/modules/ragstack-js/pages/changelog-js.adoc
+++ b/docs/modules/ragstack-js/pages/changelog-js.adoc
@@ -1,0 +1,1 @@
+= Changelog

--- a/docs/modules/ragstack-js/pages/dev-environment-js.adoc
+++ b/docs/modules/ragstack-js/pages/dev-environment-js.adoc
@@ -1,0 +1,1 @@
+= Local Development Environment

--- a/docs/modules/ragstack-js/pages/index.adoc
+++ b/docs/modules/ragstack-js/pages/index.adoc
@@ -1,0 +1,1 @@
+= Index for RAGStack-JS

--- a/docs/modules/ragstack-js/pages/migration-js.adoc
+++ b/docs/modules/ragstack-js/pages/migration-js.adoc
@@ -1,0 +1,1 @@
+= Migrate to RAGStack-JS

--- a/docs/modules/ragstack-js/pages/quickstart-js.adoc
+++ b/docs/modules/ragstack-js/pages/quickstart-js.adoc
@@ -1,0 +1,1 @@
+= Quickstart


### PR DESCRIPTION
Standing up new ragstack-js module. 
Some things will probably change but for now there is a scaffold to work on.

Left sidebar:
Get started
Get started (JS/TS)
    Quickstart
    Local development
    Migrate to RAGStack
...
Release notes
    Changelog
    Changelog (JS/TS)

<img width="1728" alt="Screenshot 2024-04-05 at 3 08 05 PM" src="https://github.com/datastax/ragstack-ai/assets/59585235/4447deed-889e-456d-9722-63d2675109e3">
![Screenshot 2024-04-05 at 3 08 05 PM (2)](https://github.com/datastax/ragstack-ai/assets/59585235/50915854-6449-4f9e-819e-43036779efac)

   