### PR TITLE
[deps]: update astrapy and langchain-astradb versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{ include = "ragstack" }]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-astrapy = ">=0.7.7, <2"
+astrapy = "^1"
 cassio = "~0.1.4"
 unstructured = "0.12.5"
 
@@ -39,7 +39,7 @@ llama-index-embeddings-gemini = { version = "0.1.6", optional = true }
 langchain = "0.1.12"
 langchain-core = "0.1.31"
 langchain-community = "0.0.28"
-langchain-astradb = "0.1.0"
+langchain-astradb = "0.2.0"
 langchain-openai = "0.0.8"
 langchain-google-genai = { version = "1.0.1", optional = true }
 langchain-google-vertexai = { version = "0.1.0", optional = true }

--- a/ragstack-e2e-tests/pyproject.langchain.toml
+++ b/ragstack-e2e-tests/pyproject.langchain.toml
@@ -3,7 +3,7 @@ name = "ragstack-e2e-tests"
 version = "0.1.0"
 description = "RAGStack tests"
 license = ""
-authors = ["DataStax"]
+authors = [ "DataStax" ]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12,!=3.9.7"
@@ -52,10 +52,10 @@ llama-index-llms-vertex = { version = "0.1.5" }
 llama-index-embeddings-gemini = { version = "0.1.6" }
 llama-index-llms-huggingface = "^0.1.0"
 
-astrapy = ">=0.7.7, <2"
+astrapy = "^1"
 cassio = "~0.1.4"
 unstructured = "0.12.5"
 
 [build-system]
-requires = ["poetry-core"]
+requires = [ "poetry-core" ]
 build-backend = "poetry.core.masonry.api"

--- a/ragstack-e2e-tests/pyproject.llamaindex.toml
+++ b/ragstack-e2e-tests/pyproject.llamaindex.toml
@@ -3,7 +3,7 @@ name = "ragstack-e2e-tests"
 version = "0.1.0"
 description = "RAGStack tests"
 license = ""
-authors = ["DataStax"]
+authors = [ "DataStax" ]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12,!=3.9.7"
@@ -42,17 +42,17 @@ llama-index-multi-modal-llms-gemini = { git = "https://github.com/run-llama/llam
 llama-parse = { git = "https://github.com/run-llama/llama_parse.git", branch = "main" }
 
 langchain = "0.1.12"
-langchain-astradb = "0.1.0"
+langchain-astradb = "0.2.0"
 langchain-core = "0.1.31"
 langchain-community = "0.0.28"
 langchain-openai = "0.0.8"
 langchain-google-genai = "1.0.1"
 langchain-google-vertexai = "0.1.0"
 langchain-nvidia-ai-endpoints = "0.0.3"
-astrapy = ">=0.7.7, <2"
+astrapy = "^1"
 cassio = "~0.1.4"
 unstructured = "0.12.5"
 
 [build-system]
-requires = ["poetry-core"]
+requires = [ "poetry-core" ]
 build-backend = "poetry.core.masonry.api"

--- a/ragstack-e2e-tests/pyproject.ragstack-ai.toml
+++ b/ragstack-e2e-tests/pyproject.ragstack-ai.toml
@@ -3,7 +3,7 @@ name = "ragstack-e2e-tests"
 version = "0.1.0"
 description = "RAGStack tests"
 license = ""
-authors = ["DataStax"]
+authors = [ "DataStax" ]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12,!=3.9.7"
@@ -28,10 +28,10 @@ beautifulsoup4 = "^4"
 cassio = "~0.1.4"
 
 # Remove when langchain-astradb is part of ragstack-ai package
-langchain-astradb = "0.1.0"
+langchain-astradb = "0.2.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = [ "poetry-core" ]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]


### PR DESCRIPTION
Blocked on release of `langchain-astradb` to 0.2.0. 