### PR TITLE
use query token mask to optimize for effective tokens

### DIFF
--- a/libs/colbert/ragstack_colbert/base_embedding_model.py
+++ b/libs/colbert/ragstack_colbert/base_embedding_model.py
@@ -62,3 +62,21 @@ class BaseEmbeddingModel(ABC):
         Returns:
             Tensor: A tensor representing the embedded query.
         """
+
+    @abstractmethod
+    def optimized_query_embeddings(
+        self, query: str, query_maxlen: int = -1
+    ) -> Tensor:
+        """
+        Embeds a single query text into its vector representation for optimized retrieval.
+
+        This method is used to generate optimized query embeddings for retrieval operations. 
+        It excludes all the mask, padding, CLS, SEP tokens for faster retrieval.
+
+        Parameters:
+            query (str): The query string to encode.
+            query_maxlen (int): The fixed length for the query token embedding. If -1, uses a dynamically calculated value.
+
+        Returns:
+            Tensor: A tensor representing the embedded query for optimized retrieval.
+        """

--- a/libs/colbert/ragstack_colbert/base_retriever.py
+++ b/libs/colbert/ragstack_colbert/base_retriever.py
@@ -27,7 +27,7 @@ class BaseRetriever(ABC):
         self,
         query: str,
         k: Optional[int] = None,
-        query_maxlen: Optional[int] = None,
+        query_maxlen: int = 64,
         **kwargs: Any
     ) -> List[RetrievedChunk]:
         """
@@ -37,8 +37,7 @@ class BaseRetriever(ABC):
         Parameters:
             query (str): The query text to search for relevant text chunks.
             k (Optional[int]): The number of top results to retrieve.
-            query_maxlen (Optional[int]): The maximum length of the query to consider. If None, the
-                                          maxlen will be dynamically generated.
+            query_maxlen (int): defaults to 64 specified in the ColBERT library.
             **kwargs (Any): Additional parameters that implementations might require for customized
                             retrieval operations.
 

--- a/libs/colbert/ragstack_colbert/colbert_retriever.py
+++ b/libs/colbert/ragstack_colbert/colbert_retriever.py
@@ -288,9 +288,14 @@ class ColbertRetriever(BaseRetriever):
             embeddings, scoring these embeddings for similarity, and retrieving the corresponding text chunks.
         """
 
-        query_embeddings = self.embedding_model.embed_query(
+        query_embeddings = self.embedding_model.optimized_query_embeddings(
             query, query_maxlen=query_maxlen
         )
+
+        # make sure query embeddings is 128 dim vector
+        if query_embeddings.size(1) != 128:
+            logging.error(f"query embedding shape is {filtered_tensor.shape} but 128 dim is expected.")
+            raise ValueError("query embedding tensor shape is not 128")
 
         top_k = max(math.floor(len(query_embeddings) / 2), 16)
         logging.debug(f"based on query length of {len(query_embeddings)} tokens, retrieving {top_k} results per token-embedding")

--- a/libs/colbert/tests/integration_tests/test_colbert_embeddings.py
+++ b/libs/colbert/tests/integration_tests/test_colbert_embeddings.py
@@ -60,15 +60,3 @@ def test_colbert_token_embeddings_with_params():
     embeddings = embedded_chunks[0].embeddings
     assert len(embeddings) > 1
     assert len(embeddings[0]) == DEFAULT_COLBERT_DIM
-
-
-def test_colbert_query_embeddings():
-    colbert = ColbertEmbeddingModel()
-
-    queryTensor = colbert.embed_query("who is the president of the united states?")
-    assert isinstance(queryTensor, torch.Tensor)
-    assert queryTensor.shape == (12, 128)
-
-    # test query encoding
-    queryEncoding = colbert.embed_query("test-query", query_maxlen=512)
-    assert len(queryEncoding) == 512

--- a/libs/colbert/tests/unit_tests/test_colbert_retriever.py
+++ b/libs/colbert/tests/unit_tests/test_colbert_retriever.py
@@ -3,6 +3,11 @@ import torch
 from ragstack_colbert.colbert_retriever import max_similarity_torch
 from ragstack_colbert.colbert_embedding_model import calculate_query_maxlen
 
+from ragstack_colbert import ColbertEmbeddingModel
+from ragstack_colbert.constant import DEFAULT_COLBERT_DIM
+
+from torch.nn.functional import cosine_similarity
+
 
 def test_max_similarity_torch():
     # Example query vector and embedding list
@@ -29,10 +34,58 @@ def test_max_similarity_torch():
     ), "The max similarity does not match the expected value."
 
 
-def test_query_maxlen_calculation():
-    tokens = [["word1"], ["word2", "word3"]]
-    assert calculate_query_maxlen(tokens) == 5
+def test_colbert_query_embeddings():
+    colbert = ColbertEmbeddingModel()
+
+    text = "who is the president of the united states?"
+    queryTensor = colbert.embed_query(text)
+    assert isinstance(queryTensor, torch.Tensor)
+    assert queryTensor.shape == (64, 128)
+
+    optimizer_query_tensor = colbert.optimized_query_embeddings(
+        text, query_maxlen=512
+    )
+    assert isinstance(optimizer_query_tensor, torch.Tensor)
+    assert optimizer_query_tensor.shape == (9, DEFAULT_COLBERT_DIM)
+
+    # test query encoding
+    queryEncoding = colbert.embed_query("test-query", query_maxlen=512)
+    assert len(queryEncoding) == 512
 
 
-    tokens = [["word1", "word2", "word3"], ["word1", "word2"]]
-    assert calculate_query_maxlen(tokens) == 6
+def eval_optimized_query_embeddings(text: str): 
+    colbert = ColbertEmbeddingModel()
+
+    query_tensor = colbert.embed_query(text)
+    assert isinstance(query_tensor, torch.Tensor)
+    assert query_tensor.shape == (64, DEFAULT_COLBERT_DIM)
+
+    optimizer_query_tensor = colbert.optimized_query_embeddings(text)
+    assert isinstance(optimizer_query_tensor, torch.Tensor)
+
+    # the dimension of the tensor
+    n = optimizer_query_tensor.shape[0]
+    assert DEFAULT_COLBERT_DIM == optimizer_query_tensor.shape[1]
+
+    # evaluate the optimized query tensor's similarity with the original query tensor
+    # the original query token sequence is in this order 
+    # [101, 1, ..., 102, 103, ... 103]
+    # so the first, second Tensor will be skipped
+    tensor_adjusted = query_tensor[2:n+2]
+    for i in range(len(tensor_adjusted)):
+        similarity = cosine_similarity(optimizer_query_tensor[i].unsqueeze(0), tensor_adjusted[i].unsqueeze(0))
+        assert similarity > 0.999
+
+        distance = torch.norm(optimizer_query_tensor[i] - tensor_adjusted[i])
+        assert abs(distance) < 0.001
+
+    # Note: we do not evaluate 103 MASK token, all 103 tokens are embedded totally different
+
+
+def test_optimized_query_embeddings():
+    eval_optimized_query_embeddings("who is the president of the united states?")
+    eval_optimized_query_embeddings("me?")
+    eval_optimized_query_embeddings("how many planets are in the solar system?")
+    eval_optimized_query_embeddings("what is the largest mammal in the world?")
+    # this is 64 token long query
+    eval_optimized_query_embeddings("What are the potential benefits and drawbacks of implementing a nationwide high-speed rail network in the United States, considering the diverse geographic and demographic factors across different regions, and how might these impact the overall feasibility and sustainability of such a project?")


### PR DESCRIPTION
Revert back to use the standard query_maxlen for query token embeddings, this is the library's default.

Instead we use the query embedding's tensorize()'s mask to identify effective query tokens. It excludes 101, 1, 102, and 103.
