### PR TITLE
docs: add note about llamaindex upgrade

### DIFF
--- a/.github/workflows/dispatch-deploy-draft.yml
+++ b/.github/workflows/dispatch-deploy-draft.yml
@@ -1,3 +1,4 @@
+# yamllint disable
 name: Deploy Draft
 
 on:

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -35,6 +35,11 @@ For more, see:
 
 == `ragstack-ai-llamaindex`@1.0.0 (2024-04-24)
 
+Version 1.0.0 upgraded `llama-index` from 0.9.48 to 0.10.x, bringing possible breaking changes to existing applications.
+
+If you are upgrading from `ragstack-ai` < 1.x, you must follow the https://docs.llamaindex.ai/en/stable/getting_started/v0_10_0_migration/[official LlamaIndex migration guide].
+
+
 [caption=]
 .Requirements
 [%autowidth]


### PR DESCRIPTION
Upgrading to ragstack-ai 1.0.0 changes the llamaindex version from 0.9.x to 0.10.x which has breaking changes. 
Added a note and a link to the official llamaindex documentation for the migration guide