### PR TITLE
Docs - RAGStack x Langflow

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -13,6 +13,9 @@
 * xref:default-architecture:retrieval.adoc[]
 * xref:default-architecture:generation.adoc[]
 
+.RAGStack x Langflow
+* xref:langflow:index.adoc[]
+
 .ColBERT
 * xref:colbert:index.adoc[]
 * xref:examples:colbert.adoc[]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -13,7 +13,7 @@
 * xref:default-architecture:retrieval.adoc[]
 * xref:default-architecture:generation.adoc[]
 
-.RAGStack x Langflow
+.Langflow
 * xref:langflow:index.adoc[]
 
 .ColBERT

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -35,13 +35,9 @@ Additional LLamaIndex packages should work out of the box, although you need to 
 
 == Supported integrations for `ragstack-ai-langflow`
 
-The `ragstack-ai-langflow` package includes the minimum set of dependencies for using https://docs.langflow.org/[Langflow] with Langchain, {astra_db}, and https://python.langchain.com/docs/integrations/platforms/google[Google Vertex AI and Google Gemini API].
+The `ragstack-ai-langflow` package contains a curated set of dependencies for using https://docs.langflow.org/[Langflow] with {astra_db} and all the supported integrations by `ragstack-ai-langchain`.
 
-This package includes Langflow with `ragstack-ai-langchain[google]` as a dependency.
-
-LLMs, embeddings, and third-party providers are not included in this package by default, except for OpenAI, Azure OpenAI, and Google Vertex AI.
-
-Additional LangChain packages should work out of the box, although you need to manage the packages and their dependencies yourself.
+All the Langflow's builtin integrations are included in the `ragstack-ai-langflow` package.
 
 == ColBERT with `ragstack-ai-langchain` and `ragstack-ai-llamaindex`
 

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -5,6 +5,7 @@ RAGStack comes with a set of Python packages that provide the necessary tools to
 . `ragstack-ai`: All-in-one package that contains all components supported by RAGStack. While this is the most convenient package to use, it may be heavier than necessary for some use cases.
 . `ragstack-ai-langchain`: This package is meant for users who want to use RAGStack with the LangChain framework.
 . `ragstack-ai-llamaindex`: This package is meant for users who want to use RAGStack with the LlamaIndex framework.
+. `ragstack-ai-langflow`: This package is meant for users who want to use RAGStack with the LangFlow framework.
 . `ragstack-ai-colbert`: This package contains the implementation of the ColBERT retrieval.
 
 == Supported integrations for `ragstack-ai-langchain`
@@ -31,6 +32,16 @@ To use LLMs, embeddings, or third-party providers, you can leverage `ragstack-ai
 . `ragstack-ai-llamaindex[bedrock]` lets you work with https://docs.llamaindex.ai/en/stable/examples/llm/bedrock/[AWS Bedrock].
 
 Additional LLamaIndex packages should work out of the box, although you need to manage the packages and their dependencies yourself.
+
+== Supported integrations for `ragstack-ai-langflow`
+
+The `ragstack-ai-langflow` package includes the minimum set of dependencies for using https://docs.langflow.org/[Langflow] with Langchain, {astra_db}, and https://python.langchain.com/docs/integrations/platforms/google[Google Vertex AI and Google Gemini API].
+
+This package includes Langflow with `ragstack-ai-langchain[google]` as a dependency.
+
+LLMs, embeddings, and third-party providers are not included in this package by default, except for OpenAI, Azure OpenAI, and Google Vertex AI.
+
+Additional LangChain packages should work out of the box, although you need to manage the packages and their dependencies yourself.
 
 == ColBERT with `ragstack-ai-langchain` and `ragstack-ai-llamaindex`
 

--- a/docs/modules/langflow/pages/index.adoc
+++ b/docs/modules/langflow/pages/index.adoc
@@ -47,12 +47,6 @@ We recommend the https://pre-release.langflow.org/starter-projects/basic-prompti
 
 == The ragstack-ai-langflow package
 
-The `ragstack-ai-langflow` package includes the minimum set of dependencies for using https://docs.langflow.org/[Langflow] with Langchain, {astra_db}, and https://python.langchain.com/docs/integrations/platforms/google[Google Vertex AI and Google Gemini API].
+The `ragstack-ai-langflow` package contains a curated set of dependencies for using https://docs.langflow.org/[Langflow] with {astra_db} and all the supported integrations by `ragstack-ai-langchain`.
 
-This package includes Langflow with `ragstack-ai-langchain[google]` as a dependency.
-
-LLMs, embeddings, and third-party providers are not included in this package by default, except for OpenAI, Azure OpenAI, and Google Vertex AI.
-
-Additional LangChain packages should work out of the box, although you need to manage the packages and their dependencies yourself.
-
-
+All the Langflow's builtin integrations are included in the `ragstack-ai-langflow` package.

--- a/docs/modules/langflow/pages/index.adoc
+++ b/docs/modules/langflow/pages/index.adoc
@@ -1,4 +1,4 @@
-= RAGStack x Langflow
+= Langflow
 
 https://docs.langflow.org[Langflow^] is a visual way to build, iterate, and deploy AI applications. Its intuitive interface allows for easy manipulation of AI building blocks, enabling developers to quickly prototype and turn their ideas into powerful, real-world solutions.
 

--- a/docs/modules/langflow/pages/index.adoc
+++ b/docs/modules/langflow/pages/index.adoc
@@ -1,0 +1,51 @@
+= RAGStack x Langflow
+
+https://docs.langflow.org[Langflow^] is a visual way to build, iterate, and deploy AI applications. Its intuitive interface allows for easy manipulation of AI building blocks, enabling developers to quickly prototype and turn their ideas into powerful, real-world solutions.
+
+A single Langflow "flow" could contain multiple Langchain chat components, a Llama language model, an Astra vector store, and a Redis cache. You can build any AI flow you can think of with Langflow, but how can you be confident that these components are up-to-date and compatible with your project?
+
+Using the `ragstack-ai-langflow` package solves this problem. It provides the intuitive flow building of Langflow, with components tested for compatibility, performance, and security with RAGStack.
+
+== Install Langflow
+
+. Install Langflow.
+[source,bash]
+----
+pip install ragstack-ai-langflow
+----
++
+. Start Langflow.
++
+[source,bash]
+----
+langflow run
+----
++
+. A browser window will open with the Langflow interface.
+You can now access Langflow at `http://127.0.0.1:7860/`.
+
+[source,bash]
+----
+Result:
+
+│ Welcome to ⛓ Langflow                             │
+│                                                   │
+│ Access http://127.0.0.1:7860                      │
+│ Collaborate, and contribute at our GitHub Repo 🚀 │
+----
+
+. To create a new project, click **New Project**.
+. Select **Blank Flow** to start with a blank canvas, or select one of the **Starter Projects** to try a pre-built flow.
+We recommend the https://pre-release.langflow.org/starter-projects/basic-prompting[Basic Prompting] project to get started.
+
+== The ragsstack-ai-langflow package
+
+The `ragstack-ai-langflow` package includes the minimum set of dependencies for using https://docs.langflow.org/[Langflow] with Langchain, {astra_db}, and https://python.langchain.com/docs/integrations/platforms/google[Google Vertex AI and Google Gemini API].
+
+This package includes Langflow with `ragstack-ai-langchain[google]` as a dependency.
+
+LLMs, embeddings, and third-party providers are not included in this package by default, except for OpenAI, Azure OpenAI, and Google Vertex AI.
+
+Additional LangChain packages should work out of the box, although you need to manage the packages and their dependencies yourself.
+
+

--- a/docs/modules/langflow/pages/index.adoc
+++ b/docs/modules/langflow/pages/index.adoc
@@ -8,7 +8,8 @@ Using the `ragstack-ai-langflow` package solves this problem. It provides the in
 
 == Install Langflow
 
-. Install Langflow.
+. Install the `ragstack-ai-langflow` package.
++
 [source,bash]
 ----
 pip install ragstack-ai-langflow
@@ -16,29 +17,35 @@ pip install ragstack-ai-langflow
 +
 . Start Langflow.
 +
-[source,bash]
+[tabs]
+======
+Bash::
++
+[source,python]
 ----
 langflow run
 ----
+
+Result::
 +
-. A browser window will open with the Langflow interface.
-You can now access Langflow at `http://127.0.0.1:7860/`.
-
-[source,bash]
+[source,console]
 ----
-Result:
-
 │ Welcome to ⛓ Langflow                             │
 │                                                   │
 │ Access http://127.0.0.1:7860                      │
 │ Collaborate, and contribute at our GitHub Repo 🚀 │
 ----
-
+======
++
+A browser window will open with the Langflow interface.
++
+You can now access Langflow at `http://127.0.0.1:7860/`.
++
 . To create a new project, click **New Project**.
 . Select **Blank Flow** to start with a blank canvas, or select one of the **Starter Projects** to try a pre-built flow.
 We recommend the https://pre-release.langflow.org/starter-projects/basic-prompting[Basic Prompting] project to get started.
 
-== The ragsstack-ai-langflow package
+== The ragstack-ai-langflow package
 
 The `ragstack-ai-langflow` package includes the minimum set of dependencies for using https://docs.langflow.org/[Langflow] with Langchain, {astra_db}, and https://python.langchain.com/docs/integrations/platforms/google[Google Vertex AI and Google Gemini API].
 


### PR DESCRIPTION
Index page with dependencies, install, and link to more quickstarts.