### PR TITLE
docs: remove api reference from toc

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -49,13 +49,3 @@
 
 .Release notes
 * xref:ROOT:changelog.adoc[]
-
-.API Reference
-* https://datastax.github.io/ragstack-ai/api_reference/0.10.0/langchain[0.10.0]
-* https://datastax.github.io/ragstack-ai/api_reference/0.9.0/langchain[0.9.0]
-* https://datastax.github.io/ragstack-ai/api_reference/0.8.0/langchain[0.8.0]
-* https://datastax.github.io/ragstack-ai/api_reference/0.7.0/langchain[0.7.0]
-* https://datastax.github.io/ragstack-ai/api_reference/0.6.0/langchain[0.6.0]
-* https://datastax.github.io/ragstack-ai/api_reference/0.5.0/langchain[0.5.0]
-* https://datastax.github.io/ragstack-ai/api_reference/0.4.0/langchain[0.4.0]
-* https://datastax.github.io/ragstack-ai/api_reference/0.3.1/langchain[0.3.1]


### PR DESCRIPTION
as discussed with @mendonk let's remove the out-of-date toc for the api reference. 
All the links are available in the changelog page too