### PR TITLE
fixed colbert db sync methods

### DIFF
--- a/libs/colbert/ragstack_colbert/base_vector_store.py
+++ b/libs/colbert/ragstack_colbert/base_vector_store.py
@@ -79,8 +79,7 @@ class BaseVectorStore(ABC):
             True if the all the deletes were successful.
         """
 
-        # handles LlamaIndex add
-
+    # handles LlamaIndex add
     @abstractmethod
     async def aadd_chunks(self, chunks: List[Chunk], concurrent_inserts: Optional[int] = 100) -> List[Tuple[str, int]]:
         """


### PR DESCRIPTION
the synchronous code was using asynchronous methods behind the scenes, and would create many errors on large insertions. This reverts the synchronous methods back to synchronous code.