### PR TITLE
feat: knowlege-store concurrent traversal

### DIFF
--- a/libs/knowledge-store/ragstack_knowledge_store/content.py
+++ b/libs/knowledge-store/ragstack_knowledge_store/content.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class Kind(str, Enum):
     document = "document"
     """A root document (PDF, HTML, etc.).

--- a/libs/knowledge-store/tests/conftest.py
+++ b/libs/knowledge-store/tests/conftest.py
@@ -3,15 +3,16 @@ from typing import Iterable, Iterator, Optional
 
 import pytest
 from cassandra.cluster import Cluster, Session
+from dotenv import load_dotenv
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
-from dotenv import load_dotenv
 
 from ragstack_knowledge_store.knowledge_store import KnowledgeStore
 
 load_dotenv()
+
 
 @pytest.fixture(scope="session")
 def db_keyspace() -> str:

--- a/libs/knowledge-store/tests/test_knowledge_store.py
+++ b/libs/knowledge-store/tests/test_knowledge_store.py
@@ -1,7 +1,8 @@
 from langchain_core.documents import Document
+from precisely import assert_that, contains_exactly
+
 from .conftest import DataFixture
 
-from precisely import assert_that, contains_exactly
 
 def test_write_retrieve_href_url_pair(fresh_fixture: DataFixture):
     a = Document(
@@ -9,7 +10,7 @@ def test_write_retrieve_href_url_pair(fresh_fixture: DataFixture):
         metadata={
             "content_id": "a",
             "urls": ["http://a"],
-        }
+        },
     )
     b = Document(
         page_content="B",
@@ -17,21 +18,17 @@ def test_write_retrieve_href_url_pair(fresh_fixture: DataFixture):
             "content_id": "b",
             "hrefs": ["http://a"],
             "urls": ["http://b"],
-        }
+        },
     )
     c = Document(
         page_content="C",
         metadata={
             "content_id": "c",
             "hrefs": ["http://a"],
-        }
+        },
     )
     d = Document(
-        page_content="D",
-        metadata={
-            "content_id": "d",
-            "hrefs": ["http://a", "http://b"]
-        }
+        page_content="D", metadata={"content_id": "d", "hrefs": ["http://a", "http://b"]}
     )
 
     store = fresh_fixture.store([a, b, c, d])
@@ -40,6 +37,7 @@ def test_write_retrieve_href_url_pair(fresh_fixture: DataFixture):
     assert_that(store._linked_ids("b"), contains_exactly("a"))
     assert_that(store._linked_ids("c"), contains_exactly("a"))
     assert_that(store._linked_ids("d"), contains_exactly("a", "b"))
+
 
 def test_write_retrieve_keywords(fresh_fixture: DataFixture):
     greetings = Document(


### PR DESCRIPTION
This should speed up traversals by issuing the queries for nodes/edges/ids concurrently.