### PR TITLE
Remove dependency on precisely

### DIFF
--- a/libs/knowledge-graph/pyproject.toml
+++ b/libs/knowledge-graph/pyproject.toml
@@ -33,7 +33,6 @@ testcontainers = "~3.7.1"
 # https://github.com/psf/requests/issues/6707
 requests = "<=2.31.0"
 pytest = "^8.1.1"
-precisely = "^0.1.9"
 pytest-asyncio = "^0.23.6"
 pytest-dotenv = "^0.5.2"
 setuptools = "^70.0.0"

--- a/libs/knowledge-graph/tests/conftest.py
+++ b/libs/knowledge-graph/tests/conftest.py
@@ -3,6 +3,7 @@ from typing import Iterator, List
 
 import pytest
 from cassandra.cluster import Cluster, Session
+from dotenv import load_dotenv
 from langchain.graphs.graph_document import GraphDocument, Node, Relationship
 from langchain_core.documents import Document
 from langchain_core.language_models import BaseChatModel
@@ -10,6 +11,8 @@ from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
 from ragstack_knowledge_graph.cassandra_graph_store import CassandraGraphStore
+
+load_dotenv()
 
 
 @pytest.fixture(scope="session")
@@ -65,7 +68,9 @@ def llm() -> BaseChatModel:
 
 
 class DataFixture:
-    def __init__(self, session: Session, keyspace: str, documents: List[GraphDocument]) -> None:
+    def __init__(
+        self, session: Session, keyspace: str, documents: List[GraphDocument]
+    ) -> None:
         self.session = session
         self.keyspace = "default_keyspace"
         self.uid = secrets.token_hex(8)
@@ -130,7 +135,9 @@ def marie_curie(db_session: Session, db_keyspace: str) -> Iterator[DataFixture]:
             Relationship(source=marie_curie, target=nobel_prize, type="WON"),
             Relationship(source=pierre_curie, target=nobel_prize, type="WON"),
             Relationship(source=marie_curie, target=pierre_curie, type="MARRIED_TO"),
-            Relationship(source=marie_curie, target=university_of_paris, type="WORKED_AT"),
+            Relationship(
+                source=marie_curie, target=university_of_paris, type="WORKED_AT"
+            ),
             Relationship(source=marie_curie, target=professor, type="HAS_PROFESSION"),
         ],
         source=Document(page_content="test_content"),

--- a/libs/knowledge-graph/tests/test_extraction.py
+++ b/libs/knowledge-graph/tests/test_extraction.py
@@ -4,7 +4,6 @@ import pytest
 from langchain_community.graphs.graph_document import Node, Relationship
 from langchain_core.documents import Document
 from langchain_core.language_models import BaseChatModel
-from precisely import assert_that, contains_exactly
 
 from ragstack_knowledge_graph.extraction import (
     KnowledgeSchema,
@@ -34,6 +33,7 @@ She was, in 1906, the first woman to become a professor at the University of
 Paris.
 """
 
+
 @pytest.mark.flaky(retries=10, delay=0)
 def test_extraction(extractor: KnowledgeSchemaExtractor):
     results = extractor.extract([Document(page_content=MARIE_CURIE_SOURCE)])
@@ -50,9 +50,8 @@ def test_extraction(extractor: KnowledgeSchemaExtractor):
     # putting things into standard title case, etc.
     university_of_paris = Node(id="University Of Paris", type="Institution")
 
-    assert_that(
-        results[0].nodes,
-        contains_exactly(
+    assert sorted(results[0].nodes, key=lambda x: x.id) == sorted(
+        [
             marie_curie,
             polish,
             french,
@@ -61,18 +60,24 @@ def test_extraction(extractor: KnowledgeSchemaExtractor):
             nobel_prize,
             pierre_curie,
             university_of_paris,
-        ),
+        ],
+        key=lambda x: x.id,
     )
-    assert_that(
-        results[0].relationships,
-        contains_exactly(
+
+    assert sorted(
+        results[0].relationships, key=lambda x: (x.source.id, x.target.id, x.type)
+    ) == sorted(
+        [
             Relationship(source=marie_curie, target=polish, type="HAS_NATIONALITY"),
             Relationship(source=marie_curie, target=french, type="HAS_NATIONALITY"),
             Relationship(source=marie_curie, target=physicist, type="HAS_OCCUPATION"),
             Relationship(source=marie_curie, target=chemist, type="HAS_OCCUPATION"),
             Relationship(source=marie_curie, target=nobel_prize, type="RECEIVED"),
             Relationship(source=pierre_curie, target=nobel_prize, type="RECEIVED"),
-            Relationship(source=marie_curie, target=university_of_paris, type="WORKED_AT"),
+            Relationship(
+                source=marie_curie, target=university_of_paris, type="WORKED_AT"
+            ),
             Relationship(source=marie_curie, target=pierre_curie, type="MARRIED_TO"),
-        ),
+        ],
+        key=lambda x: (x.source.id, x.target.id, x.type),
     )

--- a/libs/knowledge-graph/tests/test_knowledge_graph.py
+++ b/libs/knowledge-graph/tests/test_knowledge_graph.py
@@ -1,12 +1,12 @@
 import secrets
 import pytest
-from precisely import assert_that, contains_exactly
 
 from cassandra.cluster import Session
 from ragstack_knowledge_graph.knowledge_graph import CassandraKnowledgeGraph
 from ragstack_knowledge_graph.traverse import Node, Relation
 
 from .conftest import DataFixture
+
 
 def test_no_embeddings(db_session: Session, db_keyspace: str) -> None:
     uid = secrets.token_hex(8)
@@ -21,6 +21,7 @@ def test_no_embeddings(db_session: Session, db_keyspace: str) -> None:
         keyspace=db_keyspace,
     )
     graph.insert([Node(name="a", type="b")])
+
 
 def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
     (result_nodes, result_edges) = marie_curie.graph_store.graph.subgraph(
@@ -40,14 +41,30 @@ def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
         Node(name="Professor", type="Profession"),
     ]
     expected_edges = {
-        Relation(Node("Marie Curie", "Person"), Node("Polish", "Nationality"), "HAS_NATIONALITY"),
-        Relation(Node("Marie Curie", "Person"), Node("French", "Nationality"), "HAS_NATIONALITY"),
         Relation(
-            Node("Marie Curie", "Person"), Node("Physicist", "Profession"), "HAS_PROFESSION"
+            Node("Marie Curie", "Person"),
+            Node("Polish", "Nationality"),
+            "HAS_NATIONALITY",
         ),
-        Relation(Node("Marie Curie", "Person"), Node("Chemist", "Profession"), "HAS_PROFESSION"),
         Relation(
-            Node("Marie Curie", "Person"), Node("Professor", "Profession"), "HAS_PROFESSION"
+            Node("Marie Curie", "Person"),
+            Node("French", "Nationality"),
+            "HAS_NATIONALITY",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Physicist", "Profession"),
+            "HAS_PROFESSION",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Chemist", "Profession"),
+            "HAS_PROFESSION",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Professor", "Profession"),
+            "HAS_PROFESSION",
         ),
         Relation(
             Node("Marie Curie", "Person"),
@@ -55,30 +72,36 @@ def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
             "RESEARCHED",
         ),
         Relation(Node("Marie Curie", "Person"), Node("Nobel Prize", "Award"), "WON"),
-        Relation(Node("Marie Curie", "Person"), Node("Pierre Curie", "Person"), "MARRIED_TO"),
+        Relation(
+            Node("Marie Curie", "Person"), Node("Pierre Curie", "Person"), "MARRIED_TO"
+        ),
         Relation(
             Node("Marie Curie", "Person"),
             Node("University of Paris", "Organization"),
             "WORKED_AT",
         ),
     }
-    assert_that(result_edges, contains_exactly(*expected_edges))
-    assert_that(result_nodes, contains_exactly(*expected_nodes))
+    assert sorted(result_edges) == sorted(expected_edges)
+    assert sorted(result_nodes) == sorted(expected_nodes)
 
 
 def test_fuzzy_search(marie_curie: DataFixture) -> None:
     if not marie_curie.has_embeddings:
-        pytest.skip("Fuzzy search requires embeddings. Run with openai environment variables")
-    result_nodes = marie_curie.graph_store.graph.query_nearest_nodes(["Marie", "Poland"])
+        pytest.skip(
+            "Fuzzy search requires embeddings. Run with openai environment variables"
+        )
+    result_nodes = marie_curie.graph_store.graph.query_nearest_nodes(
+        ["Marie", "Poland"]
+    )
     expected_nodes = [
         Node(name="Marie Curie", type="Person"),
         Node(name="Polish", type="Nationality", properties={"European": True}),
     ]
-    assert_that(result_nodes, contains_exactly(*expected_nodes))
+    assert sorted(result_nodes) == sorted(expected_nodes)
 
     result_nodes = marie_curie.graph_store.graph.query_nearest_nodes(["European"], k=2)
     expected_nodes = [
         Node(name="Polish", type="Nationality", properties={"European": True}),
         Node(name="French", type="Nationality", properties={"European": True}),
     ]
-    assert_that(result_nodes, contains_exactly(*expected_nodes))
+    assert sorted(result_nodes) == sorted(expected_nodes)

--- a/libs/knowledge-graph/tests/test_runnables.py
+++ b/libs/knowledge-graph/tests/test_runnables.py
@@ -1,12 +1,9 @@
-from precisely import assert_that, contains_exactly
-
 from ragstack_knowledge_graph.runnables import extract_entities
 from ragstack_knowledge_graph.traverse import Node
 
 
 def test_extract_entities(llm):
     extractor = extract_entities(llm)
-    assert_that(
-        extractor.invoke({"question": "Who is Marie Curie?"}),
-        contains_exactly(Node("Marie Curie", "Person")),
-    )
+    assert extractor.invoke({"question": "Who is Marie Curie?"}) == [
+        Node("Marie Curie", "Person")
+    ]

--- a/libs/knowledge-graph/tests/test_traverse.py
+++ b/libs/knowledge-graph/tests/test_traverse.py
@@ -1,5 +1,3 @@
-from precisely import assert_that, contains_exactly
-
 from ragstack_knowledge_graph.traverse import Node, Relation, atraverse, traverse
 
 from .conftest import DataFixture
@@ -13,7 +11,7 @@ def test_traverse_empty(marie_curie: DataFixture) -> None:
         session=marie_curie.session,
         keyspace=marie_curie.keyspace,
     )
-    assert_that(results, contains_exactly())
+    assert list(results) == []
 
 
 def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
@@ -25,14 +23,30 @@ def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
         keyspace=marie_curie.keyspace,
     )
     expected = {
-        Relation(Node("Marie Curie", "Person"), Node("Polish", "Nationality"), "HAS_NATIONALITY"),
-        Relation(Node("Marie Curie", "Person"), Node("French", "Nationality"), "HAS_NATIONALITY"),
         Relation(
-            Node("Marie Curie", "Person"), Node("Physicist", "Profession"), "HAS_PROFESSION"
+            Node("Marie Curie", "Person"),
+            Node("Polish", "Nationality"),
+            "HAS_NATIONALITY",
         ),
-        Relation(Node("Marie Curie", "Person"), Node("Chemist", "Profession"), "HAS_PROFESSION"),
         Relation(
-            Node("Marie Curie", "Person"), Node("Professor", "Profession"), "HAS_PROFESSION"
+            Node("Marie Curie", "Person"),
+            Node("French", "Nationality"),
+            "HAS_NATIONALITY",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Physicist", "Profession"),
+            "HAS_PROFESSION",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Chemist", "Profession"),
+            "HAS_PROFESSION",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Professor", "Profession"),
+            "HAS_PROFESSION",
         ),
         Relation(
             Node("Marie Curie", "Person"),
@@ -40,14 +54,16 @@ def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
             "RESEARCHED",
         ),
         Relation(Node("Marie Curie", "Person"), Node("Nobel Prize", "Award"), "WON"),
-        Relation(Node("Marie Curie", "Person"), Node("Pierre Curie", "Person"), "MARRIED_TO"),
+        Relation(
+            Node("Marie Curie", "Person"), Node("Pierre Curie", "Person"), "MARRIED_TO"
+        ),
         Relation(
             Node("Marie Curie", "Person"),
             Node("University of Paris", "Organization"),
             "WORKED_AT",
         ),
     }
-    assert_that(results, contains_exactly(*expected))
+    assert sorted(results) == sorted(expected)
 
     results = traverse(
         start=Node("Marie Curie", "Person"),
@@ -56,8 +72,10 @@ def test_traverse_marie_curie(marie_curie: DataFixture) -> None:
         session=marie_curie.session,
         keyspace=marie_curie.keyspace,
     )
-    expected.add(Relation(Node("Pierre Curie", "Person"), Node("Nobel Prize", "Award"), "WON"))
-    assert_that(results, contains_exactly(*expected))
+    expected.add(
+        Relation(Node("Pierre Curie", "Person"), Node("Nobel Prize", "Award"), "WON")
+    )
+    assert sorted(results) == sorted(expected)
 
 
 async def test_atraverse_empty(marie_curie: DataFixture) -> None:
@@ -68,7 +86,7 @@ async def test_atraverse_empty(marie_curie: DataFixture) -> None:
         session=marie_curie.session,
         keyspace=marie_curie.keyspace,
     )
-    assert_that(results, contains_exactly())
+    assert list(results) == []
 
 
 async def test_atraverse_marie_curie(marie_curie: DataFixture) -> None:
@@ -80,14 +98,30 @@ async def test_atraverse_marie_curie(marie_curie: DataFixture) -> None:
         keyspace=marie_curie.keyspace,
     )
     expected = {
-        Relation(Node("Marie Curie", "Person"), Node("Polish", "Nationality"), "HAS_NATIONALITY"),
-        Relation(Node("Marie Curie", "Person"), Node("French", "Nationality"), "HAS_NATIONALITY"),
         Relation(
-            Node("Marie Curie", "Person"), Node("Physicist", "Profession"), "HAS_PROFESSION"
+            Node("Marie Curie", "Person"),
+            Node("Polish", "Nationality"),
+            "HAS_NATIONALITY",
         ),
-        Relation(Node("Marie Curie", "Person"), Node("Chemist", "Profession"), "HAS_PROFESSION"),
         Relation(
-            Node("Marie Curie", "Person"), Node("Professor", "Profession"), "HAS_PROFESSION"
+            Node("Marie Curie", "Person"),
+            Node("French", "Nationality"),
+            "HAS_NATIONALITY",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Physicist", "Profession"),
+            "HAS_PROFESSION",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Chemist", "Profession"),
+            "HAS_PROFESSION",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Professor", "Profession"),
+            "HAS_PROFESSION",
         ),
         Relation(
             Node("Marie Curie", "Person"),
@@ -95,14 +129,16 @@ async def test_atraverse_marie_curie(marie_curie: DataFixture) -> None:
             "RESEARCHED",
         ),
         Relation(Node("Marie Curie", "Person"), Node("Nobel Prize", "Award"), "WON"),
-        Relation(Node("Marie Curie", "Person"), Node("Pierre Curie", "Person"), "MARRIED_TO"),
+        Relation(
+            Node("Marie Curie", "Person"), Node("Pierre Curie", "Person"), "MARRIED_TO"
+        ),
         Relation(
             Node("Marie Curie", "Person"),
             Node("University of Paris", "Organization"),
             "WORKED_AT",
         ),
     }
-    assert_that(results, contains_exactly(*expected))
+    assert sorted(results) == sorted(expected)
 
     results = await atraverse(
         start=Node("Marie Curie", "Person"),
@@ -111,8 +147,10 @@ async def test_atraverse_marie_curie(marie_curie: DataFixture) -> None:
         session=marie_curie.session,
         keyspace=marie_curie.keyspace,
     )
-    expected.add(Relation(Node("Pierre Curie", "Person"), Node("Nobel Prize", "Award"), "WON"))
-    assert_that(results, contains_exactly(*expected))
+    expected.add(
+        Relation(Node("Pierre Curie", "Person"), Node("Nobel Prize", "Award"), "WON")
+    )
+    assert sorted(results) == sorted(expected)
 
 
 def test_traverse_marie_curie_filtered_edges(marie_curie: DataFixture) -> None:
@@ -125,10 +163,18 @@ def test_traverse_marie_curie_filtered_edges(marie_curie: DataFixture) -> None:
         keyspace=marie_curie.keyspace,
     )
     expected = {
-        Relation(Node("Marie Curie", "Person"), Node("Polish", "Nationality"), "HAS_NATIONALITY"),
-        Relation(Node("Marie Curie", "Person"), Node("French", "Nationality"), "HAS_NATIONALITY"),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Polish", "Nationality"),
+            "HAS_NATIONALITY",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("French", "Nationality"),
+            "HAS_NATIONALITY",
+        ),
     }
-    assert_that(results, contains_exactly(*expected))
+    assert sorted(results) == sorted(expected)
 
 
 async def test_atraverse_marie_curie_filtered_edges(marie_curie: DataFixture) -> None:
@@ -141,7 +187,15 @@ async def test_atraverse_marie_curie_filtered_edges(marie_curie: DataFixture) ->
         keyspace=marie_curie.keyspace,
     )
     expected = {
-        Relation(Node("Marie Curie", "Person"), Node("Polish", "Nationality"), "HAS_NATIONALITY"),
-        Relation(Node("Marie Curie", "Person"), Node("French", "Nationality"), "HAS_NATIONALITY"),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("Polish", "Nationality"),
+            "HAS_NATIONALITY",
+        ),
+        Relation(
+            Node("Marie Curie", "Person"),
+            Node("French", "Nationality"),
+            "HAS_NATIONALITY",
+        ),
     }
-    assert_that(results, contains_exactly(*expected))
+    assert sorted(results) == sorted(expected)

--- a/libs/knowledge-graph/tox.ini
+++ b/libs/knowledge-graph/tox.ini
@@ -11,4 +11,4 @@ pass_env =
 commands =
     poetry install
     poetry build
-    poetry run pytest --disable-warnings {toxinidir}/tests
+    poetry run pytest -vv --disable-warnings {toxinidir}/tests

--- a/libs/knowledge-store/pyproject.toml
+++ b/libs/knowledge-store/pyproject.toml
@@ -23,7 +23,6 @@ langchain-community = "^0.2"
 ipykernel = "^6.29.4"
 langchain-openai = "^0.1.7"
 testcontainers = "~3.7.1"
-precisely = "^0.1.9"
 setuptools = "^70.0.0"
 python-dotenv = "^1.0.1"
 

--- a/libs/knowledge-store/tests/test_knowledge_store.py
+++ b/libs/knowledge-store/tests/test_knowledge_store.py
@@ -1,5 +1,4 @@
 from langchain_core.documents import Document
-from precisely import assert_that, contains_exactly
 
 from .conftest import DataFixture
 
@@ -28,15 +27,16 @@ def test_write_retrieve_href_url_pair(fresh_fixture: DataFixture):
         },
     )
     d = Document(
-        page_content="D", metadata={"content_id": "d", "hrefs": ["http://a", "http://b"]}
+        page_content="D",
+        metadata={"content_id": "d", "hrefs": ["http://a", "http://b"]},
     )
 
     store = fresh_fixture.store([a, b, c, d])
 
-    assert_that(store._linked_ids("a"), contains_exactly())
-    assert_that(store._linked_ids("b"), contains_exactly("a"))
-    assert_that(store._linked_ids("c"), contains_exactly("a"))
-    assert_that(store._linked_ids("d"), contains_exactly("a", "b"))
+    assert list(store._linked_ids("a")) == []
+    assert list(store._linked_ids("b")) == ["a"]
+    assert list(store._linked_ids("c")) == ["a"]
+    assert sorted(store._linked_ids("d")) == ["a", "b"]
 
 
 def test_write_retrieve_keywords(fresh_fixture: DataFixture):
@@ -67,13 +67,19 @@ def test_write_retrieve_keywords(fresh_fixture: DataFixture):
 
     # Doc2 is more similar, but World and Earth are similar enough that doc1 also shows up.
     results = store.similarity_search("Earth", k=2)
-    assert list(map(lambda d: d.page_content, results)) == [doc2.page_content, doc1.page_content]
+    assert list(map(lambda d: d.page_content, results)) == [
+        doc2.page_content,
+        doc1.page_content,
+    ]
 
     results = store.similarity_search("Earth", k=1)
     assert list(map(lambda d: d.page_content, results)) == [doc2.page_content]
 
     results = store.retrieve("Earth", k=2, depth=0)
-    assert set(map(lambda d: d.page_content, results)) == {doc2.page_content, doc1.page_content}
+    assert set(map(lambda d: d.page_content, results)) == {
+        doc2.page_content,
+        doc1.page_content,
+    }
 
     results = store.retrieve("Earth", k=2, depth=1)
     assert set(map(lambda d: d.page_content, results)) == {


### PR DESCRIPTION
Though `precisely` can probably bring nice Harmcrest-like assertions, it's easy to replace its `contains_exactly` by a mere `sorted` + `==` (pytest will output a nice diff).
LangChain doesn't use precisely so introducing a dependency lib will be harder when we move the tests there.
So it's better to reduce the number of libs we drag for the moment.