### PR TITLE
fix tox

### DIFF
--- a/libs/e2e-tests/tox.ini
+++ b/libs/e2e-tests/tox.ini
@@ -69,7 +69,7 @@ deps =
     ruff
 commands =
     black --check --diff --color .
-    ruff .
+    ruff check .
 
 [testenv:fix-lint]
 description = fix lint
@@ -78,7 +78,7 @@ deps =
     ruff
 commands =
     black .
-    ruff --fix .
+    ruff check --fix .
 
 [testenv:get-latest-ragstack-ai-version]
 description = get latest ragstack ai version


### PR DESCRIPTION
I've been seeing errors like:

```
lint: commands[1] /home/runner/work/ragstack-ai/ragstack-ai/libs/e2e-tests> ruff .
error: `ruff <path>` has been removed. Use `ruff check <path>` instead.
lint: exit 1 (0.01 seconds) /home/runner/work/ragstack-ai/ragstack-ai/libs/e2e-tests> ruff . pid=2005
  lint: FAIL code 1 (3.44=setup[2.90]+cmd[0.53,0.01] seconds)
  evaluation failed :( (3.50 seconds)
```

(for instance, https://github.com/datastax/ragstack-ai/actions/runs/9700728472/job/26772819838)

This should fix that by switching to `ruff check`.

Note: AFAICT, we're only running these lints on `e2e-tests` -- is it intentional that we only check formatting and stuff there?