### PR TITLE
Add HCD and DSE 6.9 examples to nav

### DIFF
--- a/docs/local-preview-playbook.yml
+++ b/docs/local-preview-playbook.yml
@@ -57,6 +57,9 @@ asciidoc:
     astra_ui: 'Astra Portal'
     support_url: 'https://support.datastax.com'
     glossary-url: 'https://docs.datastax.com/en/glossary/docs/index.html#'
+    # Antora Atlas
+    primary-site-url: https://docs.datastax.com/en
+    primary-site-manifest-url: https://docs.datastax.com/en/site-manifest.json
 
 urls:
   latest_version_segment_strategy: redirect:from

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -41,6 +41,7 @@
 
 .RAGStack Examples
 * xref:examples:index.adoc[]
+* xref:examples:prerequisites.adoc[]
 * xref:examples:hcd.adoc[]
 * xref:examples:dse-69.adoc[]
 * xref:examples:colbert.adoc[]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -41,6 +41,8 @@
 
 .RAGStack Examples
 * xref:examples:index.adoc[]
+* xref:examples:hcd.adoc[]
+* xref:examples:dse-69.adoc[]
 * xref:examples:colbert.adoc[]
 * xref:examples:knowledge-graph.adoc[]
 * xref:examples:knowledge-store.adoc[]

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -4,9 +4,9 @@ The RAGStack changelog provides information about dependency versions for each r
 
 For more, see:
 
-* https://github.com/datastax/ragstack-ai/releases[GitHub releases^]
+* https://github.com/datastax/ragstack-ai/releases[GitHub releases]
 
-* https://pypi.org/project/ragstack-ai/[PyPI^]
+* https://pypi.org/project/ragstack-ai/[PyPI]
 
 
 == `ragstack-ai`@1.0.7 (2024-05-31)
@@ -49,7 +49,7 @@ For more, see:
 | <0.2.0,>=0.1.4
 
 | langchain
-| https://datastax.github.io/ragstack-ai/api_reference/1.0.7/langchain[==0.1.19]{external-link-icon}
+| https://datastax.github.io/ragstack-ai/api_reference/1.0.7/langchain[==0.1.19]
 
 | langchain-astradb
 | ==0.3.3
@@ -110,7 +110,7 @@ For more, see:
 | <0.2.0,>=0.1.4
 
 | langchain
-| https://datastax.github.io/ragstack-ai/api_reference/1.0.6/langchain[==0.1.19]{external-link-icon}
+| https://datastax.github.io/ragstack-ai/api_reference/1.0.6/langchain[==0.1.19]
 
 | langchain-astradb
 | ==0.3.0
@@ -222,7 +222,7 @@ For more, see:
 | <0.2.0,>=0.1.4
 
 | langchain
-| https://datastax.github.io/ragstack-ai/api_reference/1.0.5/langchain[==0.1.19]{external-link-icon}
+| https://datastax.github.io/ragstack-ai/api_reference/1.0.5/langchain[==0.1.19]
 
 | langchain-astradb
 | ==0.3.0
@@ -334,7 +334,7 @@ For more, see:
 | <0.2.0,>=0.1.4
 
 | langchain
-| https://datastax.github.io/ragstack-ai/api_reference/1.0.4/langchain[==0.1.19]{external-link-icon}
+| https://datastax.github.io/ragstack-ai/api_reference/1.0.4/langchain[==0.1.19]
 
 | langchain-astradb
 | ==0.3.0
@@ -446,7 +446,7 @@ For more, see:
 | <0.2.0,>=0.1.4
 
 | langchain
-| https://datastax.github.io/ragstack-ai/api_reference/1.0.3/langchain[==0.1.19]{external-link-icon}
+| https://datastax.github.io/ragstack-ai/api_reference/1.0.3/langchain[==0.1.19]
 
 | langchain-astradb
 | ==0.3.0
@@ -558,7 +558,7 @@ For more, see:
 | <0.2.0,>=0.1.4
 
 | langchain
-| https://datastax.github.io/ragstack-ai/api_reference/1.0.2/langchain[==0.1.19]{external-link-icon}
+| https://datastax.github.io/ragstack-ai/api_reference/1.0.2/langchain[==0.1.19]
 
 | langchain-astradb
 | ==0.3.0

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -34,7 +34,7 @@ If you are already using an open-source library that is part of {product} in you
 --
 {company} has been busy helping our customers through the pains of RAG implementation, so the {product} components we've selected have withstood production workloads and stringent testing by our engineering teams for performance, compatibility, and security.
 
-* {product} leverages the https://python.langchain.com/docs/get_started/introduction[LangChain^] ecosystem and is fully compatible with https://docs.smith.langchain.com/[LangSmith^] for monitoring your AI deployments.
+* {product} leverages the https://python.langchain.com/docs/get_started/introduction[LangChain] ecosystem and is fully compatible with https://docs.smith.langchain.com/[LangSmith] for monitoring your AI deployments.
 
 * The https://docs.datastax.com/en/astra/astra-db-vector/get-started/quickstart.html[{db-serverless}] database provides the best performance and scalability for RAG applications, in addition to being particularly well-suited to RAG workloads like question answering, semantic search, and semantic caching.
 --

--- a/docs/modules/ROOT/pages/luna-for-ragstack.adoc
+++ b/docs/modules/ROOT/pages/luna-for-ragstack.adoc
@@ -1,9 +1,9 @@
 = Luna for RAGStack
 :keywords: Luna, support, expertise, RAGStack, GenAI, Retrieval-Augmented Generation, RAG
 
-Luna is a subscription to support and expertise at DataStax. It allows you to enjoy all the benefits of the components we support, with the peace of mind knowing you have direct access to the team that authors the majority of the code and supports some of the world's largest deployments. 
+Luna is a subscription to support and expertise at DataStax. It allows you to enjoy all the benefits of the components we support, with the peace of mind knowing you have direct access to the team that authors the majority of the code and supports some of the world's largest deployments.
 
-Adding external components to a GenAI platform to support development and production environments is complex. https://www.datastax.com/products/luna-ragstack[Luna for RAGStack] gives you direct access to experts who specialize in Retrieval-Augmented Generation (RAG) applications. 
+Adding external components to a GenAI platform to support development and production environments is complex. https://www.datastax.com/products/luna-ragstack[Luna for RAGStack] gives you direct access to experts who specialize in Retrieval-Augmented Generation (RAG) applications.
 
 RAGStack includes a RAG implementation, giving you a comprehensive GenAI stack that leverages xref:examples:index.adoc#langchain-astra[LangChain and Astra DB Serverless], xref:examples:index.adoc#llama-astra[LlamaIndex and Astra DB Serverless], and more. RAGStack supports integration with Vertex AI, Gemini, Bedrock, and NVIDIA NeMo embedding microservices, offering a wider array of tested, compatible embeddings and models for your applications.
 
@@ -11,10 +11,10 @@ To learn more, see the http://www.datastax.com/blog/empowering-enterprise-genai-
 
 == Luna for RAGStack subscription pricing
 
-Please https://www.datastax.com/contact-us[contact us^] for details about the Luna for RAGStack subscription options and pricing.
+Please https://www.datastax.com/contact-us[contact us] for details about the Luna for RAGStack subscription options and pricing.
 
 // TODO: update the pricing URL when it's ready just before the launch date.
-// See the https://www.datastax.com/products/luna[Luna packages] page.  
+// See the https://www.datastax.com/products/luna[Luna packages] page.
 
 == What's next?
 

--- a/docs/modules/ROOT/pages/prerequisites.adoc
+++ b/docs/modules/ROOT/pages/prerequisites.adoc
@@ -35,7 +35,7 @@ Automatically created if it doesn't exist.
 | GCP service account JSON
 | `your-project-name-999999-r99b99999999json`
 | Credentials for GCP usage.
-See the https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[GCP documentation^].
+See the https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[GCP documentation].
 
 | LlamaIndex Cloud API key
 | `llx-...`

--- a/docs/modules/default-architecture/pages/loading.adoc
+++ b/docs/modules/default-architecture/pages/loading.adoc
@@ -3,7 +3,7 @@
 Start with LangChain for loading your data instead of manually coding your own pipeline.
 LangChain likely already provides the functionalities you need.
 
-The examples use vector-enabled {db-serverless} database for the vector store and assume you have one available. If not, see xref:ROOT:prerequisites.adoc[].
+The examples use vector-enabled {db-serverless} database for the vector store and assume you have one available. If not, see xref:examples:prerequisites.adoc[].
 
 == Load PDF from file
 

--- a/docs/modules/examples/pages/dse-69.adoc
+++ b/docs/modules/examples/pages/dse-69.adoc
@@ -1,4 +1,5 @@
 = RAGStack and DataStax Enterprise (DSE) 6.9 example
+:navtitle: RAGStack with DataStax Enterprise
 
 . Pull the latest dse-server Docker image and confirm the container is in a running state.
 +

--- a/docs/modules/examples/pages/hcd.adoc
+++ b/docs/modules/examples/pages/hcd.adoc
@@ -1,4 +1,5 @@
-= RAGStack and Hyper Converged Database (HCD) example
+= RAGStack and Hyper-Converged Database (HCD) example
+:navtitle: RAGStack with Hyper-Converged Database
 
 . Clone the HCD example repository.
 +

--- a/docs/modules/examples/pages/index.adoc
+++ b/docs/modules/examples/pages/index.adoc
@@ -87,6 +87,14 @@ We're actively updating this section, so check back often!
 | Store external or proprietary data in {db-serverless} and query it to provide more up-to-date LLM responses.
 | https://colab.research.google.com/github/datastax/ragstack-ai/blob/main/examples/notebooks/RAG_with_cassio.ipynb[Open in Colab]
 | xref:rag-with-cassio.adoc[]
+
+| Use the self-managed Hyper-Converged Database (HCD) as a vector backend for your RAG application.
+|
+| xref:hcd.adoc[]
+
+| Use DataStax Enterprise as a vector backend for your RAG application.
+|
+| xref:dse-69.adoc[]
 |===
 
 

--- a/docs/modules/examples/pages/langchain_multimodal_gemini.adoc
+++ b/docs/modules/examples/pages/langchain_multimodal_gemini.adoc
@@ -25,7 +25,7 @@ DB Access Token] with Database Administrator permissions.
 pip install google-cloud-aiplatform ragstack-ai --upgrade
 ----
 
-See the xref:ROOT:prerequisites.adoc[] page for more details.
+See the xref:examples:prerequisites.adoc[] page for more details.
 
 == Configure {db-serverless} and GCP credentials
 

--- a/docs/modules/examples/pages/langchain_multimodal_gemini.adoc
+++ b/docs/modules/examples/pages/langchain_multimodal_gemini.adoc
@@ -17,7 +17,7 @@ vector database].
 DB Access Token] with Database Administrator permissions.
 * Get your {db-serverless} API Endpoint:
 ** `https://<ASTRA_DB_ID>-<ASTRA_DB_REGION>.apps.astra.datastax.com`
-* Create a https://cloud.google.com/[GCP account^] and a https://cloud.google.com/iam/docs/service-account-overview[service account^]. Download your service account's GCP credentials as a JSON file. For more on service account authorization, see the https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[GCP documentation^].
+* Create a https://cloud.google.com/[GCP account] and a https://cloud.google.com/iam/docs/service-account-overview[service account]. Download your service account's GCP credentials as a JSON file. For more on service account authorization, see the https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[GCP documentation].
 * Install the following dependencies:
 +
 [source,python]

--- a/docs/modules/examples/pages/prerequisites.adoc
+++ b/docs/modules/examples/pages/prerequisites.adoc
@@ -46,4 +46,4 @@ If a notebook needs additional dependencies, we'll show you how to install them.
 
 == What's next?
 
-With your prerequisites set up, run the xref:quickstart.adoc[]!
+With your prerequisites set up, run the xref:ROOT:quickstart.adoc[]!

--- a/docs/modules/examples/pages/qa-with-cassio.adoc
+++ b/docs/modules/examples/pages/qa-with-cassio.adoc
@@ -51,7 +51,7 @@ from cassandra.auth import PlainTextAuthProvider
 +
 [NOTE]
 ====
-You will need a secure connect bundle and a user with access permission. For demo purposes, the "administrator" role will work fine. For more, see  xref:ROOT:prerequisites.adoc[Prerequisites].
+You will need a secure connect bundle and a user with access permission. For demo purposes, the "administrator" role will work fine. For more, see  xref:examples:prerequisites.adoc[Prerequisites].
 ====
 +
 . Initialize the environment variables.

--- a/docs/modules/examples/pages/rag-with-cassio.adoc
+++ b/docs/modules/examples/pages/rag-with-cassio.adoc
@@ -13,7 +13,7 @@ A solution to this problem is Retrieval Augmentated Generation (RAG). The idea b
 
 == Get started with this notebook
 
-See xref:ROOT:prerequisites.adoc[Prerequisites] for instructions on setting up your environment.
+See xref:examples:prerequisites.adoc[Prerequisites] for instructions on setting up your environment.
 
 . Install the following libraries.
 +

--- a/docs/modules/examples/partials/prerequisites.adoc
+++ b/docs/modules/examples/partials/prerequisites.adoc
@@ -2,7 +2,7 @@
 
 You will need an vector-enabled {db-serverless} database and an OpenAI Account.
 
-See the xref:ROOT:prerequisites.adoc[] page for more details.
+See the xref:examples:prerequisites.adoc[] page for more details.
 
 . Create an vector-enabled {db-serverless} database.
 . Create an OpenAI account

--- a/docs/modules/langflow/pages/index.adoc
+++ b/docs/modules/langflow/pages/index.adoc
@@ -1,6 +1,6 @@
 = Langflow
 
-https://docs.langflow.org[Langflow^] is a visual way to build, iterate, and deploy AI applications. Its intuitive interface allows for easy manipulation of AI building blocks, enabling developers to quickly prototype and turn their ideas into powerful, real-world solutions.
+https://docs.langflow.org[Langflow] is a visual way to build, iterate, and deploy AI applications. Its intuitive interface allows for easy manipulation of AI building blocks, enabling developers to quickly prototype and turn their ideas into powerful, real-world solutions.
 
 A single Langflow "flow" could contain multiple Langchain chat components, a Llama language model, an Astra vector store, and a Redis cache. You can build any AI flow you can think of with Langflow, but how can you be confident that these components are up-to-date and compatible with your project?
 

--- a/docs/modules/ragstack-ts/pages/changelog.adoc
+++ b/docs/modules/ragstack-ts/pages/changelog.adoc
@@ -4,9 +4,9 @@ The RAGStack changelog provides information about new features, bug fixes, depen
 
 For more, see:
 
-* https://github.com/datastax/ragstack-ai-ts/releases[GitHub releases^]{external-link-icon}
+* https://github.com/datastax/ragstack-ai-ts/releases[GitHub releases]
 
-* https://www.npmjs.com/package/@datastax/ragstack-ai[NPM^]{external-link-icon}
+* https://www.npmjs.com/package/@datastax/ragstack-ai[NPM]
 
 
 == 1.0.0

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6,9 +6,10 @@
     "": {
       "name": "ragstack-ai",
       "dependencies": {
+        "@antora/atlas-extension": "^1.0.0-alpha.2",
         "@antora/collector-extension": "^1.0.0-alpha.3",
         "@asciidoctor/tabs": "^1.0.0-beta.6",
-        "antora": "~3.1",
+        "antora": "3.2.0-alpha.4",
         "asciidoctor-external-callout": "~1.2.1",
         "asciidoctor-kroki": "~0.18.1",
         "csv-parser": "^3.0.0",
@@ -28,11 +29,11 @@
       }
     },
     "node_modules/@antora/asciidoc-loader": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-3.1.7.tgz",
-      "integrity": "sha512-sM/poPtAi8Cx0g2oLGHoEYjTdE9pvIYLgbHW07fGf6c9wQYMd2DMsevtbhNKWp+xqxj/QinToz4JOaNLoy1nfg==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-FRNq3ErMFMJPHxYQxHyuMdX4YULs9aXc+njmAoMGbyO9SNAYCwzirOBXVQegefcGDn85Y/3zLU6BanZNpxCaXQ==",
       "dependencies": {
-        "@antora/logger": "3.1.7",
+        "@antora/logger": "3.2.0-alpha.4",
         "@antora/user-require-helper": "~2.0",
         "@asciidoctor/core": "~2.2"
       },
@@ -41,9 +42,9 @@
       }
     },
     "node_modules/@antora/asciidoc-loader/node_modules/@asciidoctor/core": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.7.tgz",
-      "integrity": "sha512-63cfnV606vXNUnh/zcuUi5e3tY5qTzaYY5pGP4p9sRk8CcCmX4Z8OfU0BkfM8/k2Y7Cz/jZqxL+vzHjrLQa8tw==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.8.tgz",
+      "integrity": "sha512-oozXk7ZO1RAd/KLFLkKOhqTcG4GO3CV44WwOFg2gMcCsqCUTarvMT7xERIoWW2WurKbB0/ce+98r01p8xPOlBw==",
       "dependencies": {
         "asciidoctor-opal-runtime": "0.3.3",
         "unxhr": "1.0.1"
@@ -62,13 +63,27 @@
         "node": ">=8.11"
       }
     },
-    "node_modules/@antora/cli": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/cli/-/cli-3.1.7.tgz",
-      "integrity": "sha512-yHo30VmiLLsZU4JW8VZR6fql9m5lIxocA2d0tduKQ+r4YSD1kt+bbwX3You3iMwW7oLoNo62zfU76F8CQBnm2g==",
+    "node_modules/@antora/atlas-extension": {
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@antora/atlas-extension/-/atlas-extension-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-tOQy3eQjvoYGV3UnDaOjkaCehbWSpjQWRdCCYXx8c2Do4rysclOVVN4t4AsfeOHK+BoWlKqa7mldb1DCYOBQTw==",
       "dependencies": {
-        "@antora/logger": "3.1.7",
-        "@antora/playbook-builder": "3.1.7",
+        "@antora/expand-path-helper": "~2.0",
+        "cache-directory": "~2.0",
+        "node-gzip": "~1.1",
+        "simple-get": "~4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@antora/cli": {
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/cli/-/cli-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-tRTdO1Cp5hmV4sZZbD/Y0bZ+fQSCcESc1Y8txmCG+25lFC8PefjKC0mgWOq25RAjNxlUZ390DU35NNR9McjUsA==",
+      "dependencies": {
+        "@antora/logger": "3.2.0-alpha.4",
+        "@antora/playbook-builder": "3.2.0-alpha.4",
         "@antora/user-require-helper": "~2.0",
         "commander": "~10.0"
       },
@@ -95,12 +110,12 @@
       }
     },
     "node_modules/@antora/content-aggregator": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-3.1.7.tgz",
-      "integrity": "sha512-2gBbxaDxqY4QRw9Vut0IbKNqI9zAAohxjT0zcA5Am10kE3ywvzXaBa3tvb+A7vUl/vRcCC0LPM7pO37RVrbsGA==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-+Y6WybHnNN7bw/MFUPL8ca6SiNqT2AUZCI1NRhwYym2JD6dBIwGedNEh76a7MGTObQXKjlBrmm025FHBWg4j5Q==",
       "dependencies": {
         "@antora/expand-path-helper": "~2.0",
-        "@antora/logger": "3.1.7",
+        "@antora/logger": "3.2.0-alpha.4",
         "@antora/user-require-helper": "~2.0",
         "braces": "~3.0",
         "cache-directory": "~2.0",
@@ -120,11 +135,11 @@
       }
     },
     "node_modules/@antora/content-aggregator/node_modules/isomorphic-git": {
-      "version": "1.25.9",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.25.9.tgz",
-      "integrity": "sha512-s/KFSOP2/0I8EK0RreK9ZHurUW2At30jDEp1W0WUWT0ANtEKt4ArQbSgoUsZ0tyTiiUnTvR3MYx6BtrHwAEa1Q==",
+      "version": "1.25.10",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.25.10.tgz",
+      "integrity": "sha512-IxGiaKBwAdcgBXwIcxJU6rHLk+NrzYaaPKXXQffcA0GW3IUrQXdUPDXDo+hkGVcYruuz/7JlGBiuaeTCgIgivQ==",
       "dependencies": {
-        "async-lock": "^1.1.0",
+        "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
         "crc-32": "^1.2.0",
         "diff3": "0.0.3",
@@ -149,12 +164,12 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/@antora/content-classifier": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-3.1.7.tgz",
-      "integrity": "sha512-94XwJ35pkWJU6dJqQg5oreJRCkaXwU6yw9XSyB731o4i/0romkazKnu7deHugqdgvzqn92AlMRG6R0clhJLEsw==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-XN5JzSum/nxv1fEb7j8vFG1FLaEnBXnPxzY+hC1/pGODXVVlFVyRoxR35fx91oJ8TgVIHI+bLvymsF/MJYYmbQ==",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.7",
-        "@antora/logger": "3.1.7",
+        "@antora/asciidoc-loader": "3.2.0-alpha.4",
+        "@antora/logger": "3.2.0-alpha.4",
         "mime-types": "~2.1",
         "vinyl": "~2.2"
       },
@@ -163,11 +178,11 @@
       }
     },
     "node_modules/@antora/document-converter": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/document-converter/-/document-converter-3.1.7.tgz",
-      "integrity": "sha512-cRVJf7QyclxjWbA0gWz7hncZYThIREikkwaxaa26LsRCfBNlw7wxs7lWejvIvEl1LVshupbinJwKUPPQPOsHhw==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/document-converter/-/document-converter-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-Wbh76FELpHBfqvnKiAPvXtxkTeGP0Fk/2nZBkmTTWbpBSs98o7YfNWnVQ9Ky86jdXGmxM+LMNFoXKVIzNbpd3g==",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.7"
+        "@antora/asciidoc-loader": "3.2.0-alpha.4"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -182,9 +197,9 @@
       }
     },
     "node_modules/@antora/file-publisher": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/file-publisher/-/file-publisher-3.1.7.tgz",
-      "integrity": "sha512-UH2o0DJuv9BJvWgn+QSE3MhtHB3oN3lG5lJkV3fQi1jAV+qPIHoiTIYhbw02mj5KQ3Qbt7YWWAKZKuGl3rEdjg==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/file-publisher/-/file-publisher-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-DqH5RpdcshVhA4Xq2JQ2M7Rk3IhrOtV5ivI+oXU4yQlQW7IqchJnCmsOa885xPo8f5v2fpXRaZ5iyvRBUMaH2A==",
       "dependencies": {
         "@antora/expand-path-helper": "~2.0",
         "@antora/user-require-helper": "~2.0",
@@ -197,9 +212,9 @@
       }
     },
     "node_modules/@antora/logger": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/logger/-/logger-3.1.7.tgz",
-      "integrity": "sha512-Z2tfNIi9G4BnAZq26Kp30974FxCVCtvH46FOi6ClnkJg6Uf2gTrVlJERmtsDTsHjWsf1qKbnj/4b99/AU31iQg==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/logger/-/logger-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-ph+vIUVvZQHLA3EreBaViAB01IYzq0yjdcUSp5CVcqxU9+CnuuBKDvix6Pll7LJwgFJ8i3UX4mVVW1lI3h2tYg==",
       "dependencies": {
         "@antora/expand-path-helper": "~2.0",
         "pino": "~8.14",
@@ -211,22 +226,22 @@
       }
     },
     "node_modules/@antora/navigation-builder": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-3.1.7.tgz",
-      "integrity": "sha512-QvMPb0qY1zfgyLCfuEhJOpO5qSVjaVe5X/bQjSii9vDGgpIEiC2yt/hgqER37E/3zsBGEZvCH5lSLk1c7x0+EQ==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-qoF57QOIi2RvmqSYuaetA2IRoHizPXIs5kUKmk/uqiMq6akWaklSI9QHPhq6VsNgLdWaUomQ+gJCvnhjQQkw5w==",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.7"
+        "@antora/asciidoc-loader": "3.2.0-alpha.4"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/page-composer": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/page-composer/-/page-composer-3.1.7.tgz",
-      "integrity": "sha512-zJMzYznPT6Vd59nEXio/2rolkX070Nup6g4a8d4RCz0WoE8dmMidw6XFgjAHr0Lyh14/FHgBPlYXfhkDFR16Mw==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/page-composer/-/page-composer-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-LAbNdUYomqx9iCT+mP1bF17U5vIoBObD0VAtjF6IMD+b5xyDN1O82rZgHhDByn8R6es0oA6DrkQMwPH+oxR7fQ==",
       "dependencies": {
-        "@antora/logger": "3.1.7",
+        "@antora/logger": "3.2.0-alpha.4",
         "handlebars": "~4.7",
         "require-from-string": "~2.0"
       },
@@ -235,9 +250,9 @@
       }
     },
     "node_modules/@antora/playbook-builder": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-3.1.7.tgz",
-      "integrity": "sha512-lU80S1BqUy9DvqziEzRwpYTaWhOshxgrGAjf/F5VjAIaHCGVx0rZgfoI2rgFFkbVaH94kauOngdtTXDPXC1fPQ==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-79ERFWrOAaxr1iEW8qS7rMpjyYD9Lwt53Y18qIGLf0jtqgIVmmgJtaSR1qwrO/rYd2GIqWpm+s12NWzqJLZAog==",
       "dependencies": {
         "@iarna/toml": "~2.2",
         "convict": "~6.2",
@@ -249,9 +264,9 @@
       }
     },
     "node_modules/@antora/redirect-producer": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-3.1.7.tgz",
-      "integrity": "sha512-6zAHfcOb0v0829nAbn/3HMilbactjbjU7zBT9Iy6JHQfbqXT/g/mUT9N13Lj/wbq/nm0qKQJweB0Mi6BS2fbMw==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-BMm0l6jGdKN7r5xCP8cQmHy+owTwT0pXlsx1ZmTXZiq66Ec0H6ykKNQhx7scezbytlg18bwXUYNAtEQg/6c2AA==",
       "dependencies": {
         "vinyl": "~2.2"
       },
@@ -260,23 +275,23 @@
       }
     },
     "node_modules/@antora/site-generator": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/site-generator/-/site-generator-3.1.7.tgz",
-      "integrity": "sha512-39KWip9bLdQ+4ssyqjI+O0COquKHxoeznxY2/3w5pNZEoeTg8cD7kOsnWfbocw0R3Rj+kJV5MnqICFNq0nuPeA==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/site-generator/-/site-generator-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-QYaq9TMyPLHnUnyiO4AzRnU7igGE6Kc41j9ff8ijrGEK/YqxRmDTG74r8VdgdtotpSjcnXTQPJ46neJKExcKvg==",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.7",
-        "@antora/content-aggregator": "3.1.7",
-        "@antora/content-classifier": "3.1.7",
-        "@antora/document-converter": "3.1.7",
-        "@antora/file-publisher": "3.1.7",
-        "@antora/logger": "3.1.7",
-        "@antora/navigation-builder": "3.1.7",
-        "@antora/page-composer": "3.1.7",
-        "@antora/playbook-builder": "3.1.7",
-        "@antora/redirect-producer": "3.1.7",
-        "@antora/site-mapper": "3.1.7",
-        "@antora/site-publisher": "3.1.7",
-        "@antora/ui-loader": "3.1.7",
+        "@antora/asciidoc-loader": "3.2.0-alpha.4",
+        "@antora/content-aggregator": "3.2.0-alpha.4",
+        "@antora/content-classifier": "3.2.0-alpha.4",
+        "@antora/document-converter": "3.2.0-alpha.4",
+        "@antora/file-publisher": "3.2.0-alpha.4",
+        "@antora/logger": "3.2.0-alpha.4",
+        "@antora/navigation-builder": "3.2.0-alpha.4",
+        "@antora/page-composer": "3.2.0-alpha.4",
+        "@antora/playbook-builder": "3.2.0-alpha.4",
+        "@antora/redirect-producer": "3.2.0-alpha.4",
+        "@antora/site-mapper": "3.2.0-alpha.4",
+        "@antora/site-publisher": "3.2.0-alpha.4",
+        "@antora/ui-loader": "3.2.0-alpha.4",
         "@antora/user-require-helper": "~2.0"
       },
       "engines": {
@@ -284,11 +299,11 @@
       }
     },
     "node_modules/@antora/site-mapper": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-3.1.7.tgz",
-      "integrity": "sha512-x++89btbwk8FxyU2+H/RHQMnsC9sdvQvXcwXwNt11eXN1qj7t8TPiQZTalg7gkf0/osY4l7JRpGBY5JJfOJVig==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-9SD2HOxqYjNQ88qg4QDVbIvSyd3aYeVAUwdA50eRvWLgnToTwDorjt/nfZnbRXGNszWil9nOZ+F8+LV2BkPpTw==",
       "dependencies": {
-        "@antora/content-classifier": "3.1.7",
+        "@antora/content-classifier": "3.2.0-alpha.4",
         "vinyl": "~2.2"
       },
       "engines": {
@@ -296,20 +311,20 @@
       }
     },
     "node_modules/@antora/site-publisher": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-3.1.7.tgz",
-      "integrity": "sha512-zHaJc7UeBfFSIhBbQ5U5Ud4u671M84oqSJb3pPxlUiJDP7iVJlSl+0GNm0NAIoDizjPtVksUI88fzqCy5rfSUQ==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-GiakkrGR/eTjh7o/ZISoYDUcDSXn/zodXTiX++fqHSrzscWTOcId4IC3Lj8oRDmISrh7U3la6Ydtld4xMbtSsQ==",
       "dependencies": {
-        "@antora/file-publisher": "3.1.7"
+        "@antora/file-publisher": "3.2.0-alpha.4"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/ui-loader": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-3.1.7.tgz",
-      "integrity": "sha512-79QuZB0c91dveoESa3RcE18ZZFJo0rDZX9aJKHVc20dInQBGCgfURPqB2OytkzaXD3lNtDJ41yjKNYZqsAQy1Q==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-I7srOOR/tsORa+L+xIkPCVR365yQKO1JEylDkQbaMhbuPFhTmRV4mQXgUeLsfprtVXiSoaFw960SrWd77TX/dA==",
       "dependencies": {
         "@antora/expand-path-helper": "~2.0",
         "@vscode/gulp-vinyl-zip": "~2.5",
@@ -529,12 +544,12 @@
       }
     },
     "node_modules/antora": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/antora/-/antora-3.1.7.tgz",
-      "integrity": "sha512-8MHjWYhzSnf2cVk/fonGw7SvYu9G+gNAhS0VX3jkGou6dBHFxgqlnrlzteXgeGd5rtixMVLIwvrQgEomA2LLpQ==",
+      "version": "3.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antora/-/antora-3.2.0-alpha.4.tgz",
+      "integrity": "sha512-jNAuCsM37TWOLfcMQQAw34GFFitaKjibhjEjClTddT6Zgjt4+urONSyRfVlrbmLygn3BILV0s7MQe4cPFghdbA==",
       "dependencies": {
-        "@antora/cli": "3.1.7",
-        "@antora/site-generator": "3.1.7"
+        "@antora/cli": "3.2.0-alpha.4",
+        "@antora/site-generator": "3.2.0-alpha.4"
       },
       "bin": {
         "antora": "bin/antora"
@@ -2651,6 +2666,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node_modules/node-gzip": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/node-gzip/-/node-gzip-1.1.2.tgz",
+      "integrity": "sha512-ZB6zWpfZHGtxZnPMrJSKHVPrRjURoUzaDbLFj3VO70mpLTW5np96vXyHwft4Id0o+PYIzgDkBUjIzaNHhQ8srw=="
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -4231,9 +4251,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+      "integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -4370,6 +4390,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,13 +9,14 @@
     "url": "https://github.com/datastax/ragstack-ai.git"
   },
   "scripts": {
-    "build:local": "env FORCE_SHOW_EDIT_PAGE_LINK=true antora --clean --stacktrace local-preview-playbook.yml",
-    "tailwindcss": "tailwindcss build -c ./build/site/_/js/tailwind.config.js -i ./build/site/_/css/site.css -o ./build/site/_/css/site.css --minify"
+    "tailwindcss": "tailwindcss build -c ./build/site/_/js/tailwind.config.js -i ./build/site/_/css/site.css -o ./build/site/_/css/site.css --minify",
+    "build:local": "env FORCE_SHOW_EDIT_PAGE_LINK=true antora --clean --fetch --stacktrace local-preview-playbook.yml"
   },
   "dependencies": {
+    "@antora/atlas-extension": "^1.0.0-alpha.2",
     "@antora/collector-extension": "^1.0.0-alpha.3",
     "@asciidoctor/tabs": "^1.0.0-beta.6",
-    "antora": "~3.1",
+    "antora": "3.2.0-alpha.4",
     "asciidoctor-external-callout": "~1.2.1",
     "asciidoctor-kroki": "~0.18.1",
     "csv-parser": "^3.0.0",


### PR DESCRIPTION
The HCD and DSE 6.9 examples needed to be added to the nav. I updated some external links to comply with our updated style guidelines.

@mendonk Do these pages also need to be added to the [examples index](https://github.com/datastax/ragstack-ai/blob/main/docs/modules/examples/pages/index.adoc)? Also, while making this change, I noticed that there is an orphan page that needs to be dealt with: https://datastax.jira.com/browse/DOC-4477