### PR TITLE
feat: Reduce sequential queries for MMR

### DIFF
--- a/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
+++ b/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
@@ -448,7 +448,7 @@ class GraphStore:
             candidates = {}
             for row in fetched:
                 candidates[row.content_id] = row.text_embedding
-                outgoing_tags[row.content_id] = set(row.link_to_tags)
+                outgoing_tags[row.content_id] = set(row.link_to_tags or [])
             helper.add_candidates(candidates)
 
         fetch_initial_candidates()
@@ -682,7 +682,7 @@ class GraphStore:
                     targets[row.target_content_id] = _Edge(
                         target_content_id=row.target_content_id,
                         target_text_embedding=row.target_text_embedding,
-                        target_link_to_tags=set(row.target_link_to_tags),
+                        target_link_to_tags=set(row.target_link_to_tags or []),
                     )
 
         with self._concurrent_queries() as cq:

--- a/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
+++ b/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
@@ -107,7 +107,7 @@ _CQL_IDENTIFIER_PATTERN = re.compile(r"[a-zA-Z][a-zA-Z0-9_]*")
 class _Edge:
     target_content_id: str
     target_text_embedding: List[float]
-    target_link_to_tags: List[Tuple[str, str]]
+    target_link_to_tags: Set[Tuple[str, str]]
 
 
 class GraphStore:
@@ -440,7 +440,7 @@ class GraphStore:
 
         # Fetch the initial candidates and add them to the helper and
         # outgoing_tags.
-        def fetch_initial_candidates():
+        def fetch_initial_candidates() -> None:
             fetched = self._session.execute(
                 self._query_ids_and_embedding_by_embedding,
                 (query_embedding, fetch_k),
@@ -682,7 +682,7 @@ class GraphStore:
                     targets[row.target_content_id] = _Edge(
                         target_content_id=row.target_content_id,
                         target_text_embedding=row.target_text_embedding,
-                        target_link_to_tags=row.target_link_to_tags,
+                        target_link_to_tags=set(row.target_link_to_tags),
                     )
 
         with self._concurrent_queries() as cq:


### PR DESCRIPTION
This denormalizes the outgoing tags into the `links` table, so that
traversal doesn't need to fetch the set of outgoing tags in an initial
query. This means that traversing is one batch of concurrent queries,
rather than two steps in sequence.

This lowers average retrieval time in 6 experiments from 1.3364s to
1.0920s (would increase as more nodes are retrieved). Writing the
additional copies of the denormalized tags adds a little to indexing
time.