### PR TITLE
feat: Eliminate the targets table

### DIFF
--- a/libs/knowledge-store/notebooks/astra_support.ipynb
+++ b/libs/knowledge-store/notebooks/astra_support.ipynb
@@ -258,7 +258,6 @@
     "graph_store = CassandraGraphStore(\n",
     "    embeddings,\n",
     "    node_table=f\"{SITE_PREFIX}_nodes\",\n",
-    "    targets_table=f\"{SITE_PREFIX}_targets\",\n",
     ")"
    ]
   },

--- a/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
+++ b/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
@@ -235,7 +235,8 @@ class GraphStore:
             """  # noqa: S608
         )
 
-        self._query_targets_by_kind_and_value = session.prepare(f"""
+        self._query_targets_by_kind_and_value = session.prepare(
+            f"""
             SELECT
                 content_id AS target_content_id
             FROM {keyspace}.{node_table}
@@ -261,7 +262,6 @@ class GraphStore:
                 PRIMARY KEY (content_id)
             )
         """)
-
 
         # Index on text_embedding (for similarity search)
         self._session.execute(f"""

--- a/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
+++ b/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
@@ -130,7 +130,6 @@ class GraphStore:
         session: Optional[Session] = None,
         keyspace: Optional[str] = None,
         setup_mode: SetupMode = SetupMode.SYNC,
-        **kwargs: Any, #noqa: ARG002
     ):
         session = check_resolve_session(session)
         keyspace = check_resolve_keyspace(keyspace)

--- a/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
+++ b/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
@@ -246,8 +246,8 @@ class GraphStore:
     def _apply_schema(self) -> None:
         """Apply the schema to the database."""
         embedding_dim = len(self._embedding.embed_query("Test Query"))
-        self._session.execute(
-            f"""CREATE TABLE IF NOT EXISTS {self._keyspace}.{self._node_table} (
+        self._session.execute(f"""
+            CREATE TABLE IF NOT EXISTS {self._keyspace}.{self._node_table} (
                 content_id TEXT,
                 kind TEXT,
                 text_content TEXT,
@@ -260,8 +260,7 @@ class GraphStore:
 
                 PRIMARY KEY (content_id)
             )
-            """
-        )
+        """)
 
 
         # Index on text_embedding (for similarity search)

--- a/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
+++ b/libs/knowledge-store/ragstack_knowledge_store/graph_store.py
@@ -130,7 +130,7 @@ class GraphStore:
         session: Optional[Session] = None,
         keyspace: Optional[str] = None,
         setup_mode: SetupMode = SetupMode.SYNC,
-        **kwargs: Any,
+        **kwargs: Any, #noqa: ARG002
     ):
         session = check_resolve_session(session)
         keyspace = check_resolve_keyspace(keyspace)
@@ -158,8 +158,8 @@ class GraphStore:
         self._insert_passage = session.prepare(
             f"""
             INSERT INTO {keyspace}.{node_table} (
-                content_id, kind, text_content, text_embedding, link_to_tags, link_from_tags,
-                metadata_blob, links_blob
+                content_id, kind, text_content, text_embedding, link_to_tags,
+                link_from_tags, metadata_blob, links_blob
             ) VALUES (?, '{Kind.passage}', ?, ?, ?, ?, ?, ?)
             """  # noqa: S608
         )
@@ -232,7 +232,7 @@ class GraphStore:
             WHERE link_from_tags CONTAINS (?, ?)
             ORDER BY text_embedding ANN of ?
             LIMIT ?
-            """  # noqa: S608
+            """
         )
 
         self._query_targets_by_kind_and_value = session.prepare(
@@ -241,7 +241,7 @@ class GraphStore:
                 content_id AS target_content_id
             FROM {keyspace}.{node_table}
             WHERE link_from_tags CONTAINS (?, ?)
-            """  # noqa: S608
+            """
         )
 
     def _apply_schema(self) -> None:

--- a/libs/knowledge-store/tests/integration_tests/test_graph_store.py
+++ b/libs/knowledge-store/tests/integration_tests/test_graph_store.py
@@ -51,13 +51,11 @@ def graph_store_factory(
         name = secrets.token_hex(8)
 
         node_table = f"nodes_{name}"
-        targets_table = f"targets_{name}"
         return GraphStore(
             embedding,
             session=session,
             keyspace=KEYSPACE,
             node_table=node_table,
-            targets_table=targets_table,
         )
 
     yield _make_graph_store

--- a/libs/langchain/ragstack_langchain/graph_store/cassandra.py
+++ b/libs/langchain/ragstack_langchain/graph_store/cassandra.py
@@ -39,7 +39,6 @@ class CassandraGraphStore(GraphStore):
         embedding: Embeddings,
         *,
         node_table: str = "graph_nodes",
-        targets_table: str = "graph_targets",
         session: Optional[Session] = None,
         keyspace: Optional[str] = None,
         setup_mode: SetupMode = SetupMode.SYNC,
@@ -63,7 +62,6 @@ class CassandraGraphStore(GraphStore):
         self.store = graph_store.GraphStore(
             embedding=_EmbeddingModelAdapter(embedding),
             node_table=node_table,
-            targets_table=targets_table,
             session=session,
             keyspace=keyspace,
             setup_mode=_setup_mode,

--- a/libs/langchain/tests/integration_tests/test_graph_store.py
+++ b/libs/langchain/tests/integration_tests/test_graph_store.py
@@ -20,7 +20,6 @@ class GraphStoreFactory:
         self.keyspace = keyspace
         self.uid = secrets.token_hex(8)
         self.node_table = f"nodes_{self.uid}"
-        self.targets_table = f"targets_{self.uid}"
         self.embedding = embedding
         self._store = None
 
@@ -39,7 +38,6 @@ class GraphStoreFactory:
                 session=self.session,
                 keyspace=self.keyspace,
                 node_table=self.node_table,
-                targets_table=self.targets_table,
                 ids=ids,
             )
 
@@ -47,9 +45,6 @@ class GraphStoreFactory:
 
     def drop(self):
         self.session.execute(f"DROP TABLE IF EXISTS {self.keyspace}.{self.node_table};")
-        self.session.execute(
-            f"DROP TABLE IF EXISTS {self.keyspace}.{self.targets_table};"
-        )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This seems to be unnecessary. An SAI index supporting contains seems to be sufficient. Eliminating it removes the need to create the denormalized copy of the data, speeding up insertion and reducing storage needs.