### PR TITLE
Only dispatch drafts on changes in docs directory

### DIFF
--- a/.github/workflows/dispatch-deploy-draft.yml
+++ b/.github/workflows/dispatch-deploy-draft.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - '**'
+    paths:
+      - 'docs/**'
+      - '.github/workflows/dispatch-deploy-draft.yml'
 
 jobs:
   dispatch-deploy:


### PR DESCRIPTION
Prevents draft comments except for pull requests that include changes to the docs themselves (as well as changes to the workflow itself).