### PR TITLE
Update draft dispatch workflow to use managed PAT

### DIFF
--- a/.github/workflows/dispatch-deploy-draft.yml
+++ b/.github/workflows/dispatch-deploy-draft.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           owner: riptano
           repo: datastax-docs-site
-          github_token: ${{ secrets.DISPATCH_GITHUB_TOKEN }}
-          github_user: ${{ secrets.DISPATCH_GITHUB_USER }}
+          github_token: ${{ secrets.DOC_GITHUB_PAT_CROSS_ORG }}
           workflow_file_name: deploy-draft.yml
           client_payload: '{ "build_repository": "${{ github.event.repository.full_name }}", "build_branch": "${{ github.base_ref }}", "draft_branch": "${{ github.event.pull_request.head.ref }}", "pull_request_number": "${{ github.event.pull_request.number }}" }'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow used to dispatch draft builds to our build repository. The workflow will now use a managed personal access token.